### PR TITLE
Added 20.2 updates to Access Transformer sections

### DIFF
--- a/docs/advanced/accesstransformers.mdx
+++ b/docs/advanced/accesstransformers.mdx
@@ -30,7 +30,7 @@ minecraft {
 ```toml
 # In mods.toml:
 [[accessTransformers]]
-file="META-INF/accesstransformer.at"
+file="META-INF/accesstransformer.cfg"
 ```
 
 AT files can be anywhere specified by the lines above, though NeoForge will default to searching for `META-INF/accesstransformer.cfg` if no other file is specified.
@@ -50,10 +50,10 @@ minecraft {
 ```toml
 # In mods.toml
 [[accessTransformers]]
-file="accesstransformer_main.at"
+file="accesstransformer_main.cfg"
 
 [[accessTransformers]]
-file="accesstransformer_additions.at"
+file="accesstransformer_additions.cfg"
 ```
 
 After adding or modifying any Access Transformer, the Gradle project must be refreshed for the transformations to take effect.

--- a/docs/advanced/accesstransformers.mdx
+++ b/docs/advanced/accesstransformers.mdx
@@ -1,3 +1,6 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 Access Transformers
 ===================
 
@@ -10,16 +13,56 @@ Adding ATs
 
 Adding an Access Transformer to your mod project is as simple as adding a single line into your `build.gradle`:
 
+<Tabs defaultValue="latest">
+<TabItem value="latest" label="Latest">
+Access Transformers need to be declared in both `build.gradle` and `mods.toml`:
+
 ```groovy
+// In build.gradle:
 // This block is where your mappings version is also specified
 minecraft {
-  accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+  accessTransformers {
+    file('src/main/resources/META-INF/accesstransformer.cfg')
+  }
 }
 ```
 
-After adding or modifying the Access Transformer, the gradle project must be refreshed for the transformations to take effect.
+```toml
+# In mods.toml:
+[[accessTransformers]]
+file="META-INF/accesstransformer.at"
+```
 
-During development, the AT file can be anywhere specified by the line above. However, when loading in a non-development environment, Forge will only search for the exact path of `META-INF/accesstransformer.cfg` in your JAR file.
+AT files can be anywhere specified by the lines above, though NeoForge will default to searching for `META-INF/accesstransformer.cfg` if no other file is specified.
+
+Additionally, multiple AT files can be specified and will be applied in order. This can be useful for larger mods with multiple packages.
+
+```groovy
+// In build.gradle:
+minecraft {
+  accessTransformers {
+    file('src/main/resources/accesstransformer_main.cfg')
+    file('src/additions/resources/accesstransformer_additions.cfg')
+  }
+}
+```
+
+```toml
+# In mods.toml
+[[accessTransformers]]
+file="accesstransformer_main.at"
+
+[[accessTransformers]]
+file="accesstransformer_additions.at"
+```
+
+After adding or modifying any Access Transformer, the Gradle project must be refreshed for the transformations to take effect.
+</TabItem>
+
+<TabItem value="1.20.1" label="1.20.1-47.1 and older">
+
+</TabItem>
+</Tabs>
 
 Comments
 --------

--- a/docs/advanced/accesstransformers.mdx
+++ b/docs/advanced/accesstransformers.mdx
@@ -69,7 +69,7 @@ minecraft {
 }
 ```
 
-During development, the AT file can be anywhere specified by the line above. However, when loading in a non-development environment, Forge will only search for the exact path of `META-INF/accesstransformer.cfg` in your JAR file.
+During development, the AT file can be anywhere specified by the line above. However, when loading in a non-development environment, NeoForge will only search for the exact path of `META-INF/accesstransformer.cfg` in your JAR file.
 
 After adding or modifying the Access Transformer, the Gradle project must be refreshed for the transformations to take effect.
 </TabItem>

--- a/docs/advanced/accesstransformers.mdx
+++ b/docs/advanced/accesstransformers.mdx
@@ -60,7 +60,18 @@ After adding or modifying any Access Transformer, the Gradle project must be ref
 </TabItem>
 
 <TabItem value="1.20.1" label="1.20.1-47.1 and older">
+Adding an Access Transformer to your mod project is as simple as adding a single line into your `build.gradle`:
 
+```groovy
+// This block is where your mappings version is also specified
+minecraft {
+  accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+}
+```
+
+During development, the AT file can be anywhere specified by the line above. However, when loading in a non-development environment, Forge will only search for the exact path of `META-INF/accesstransformer.cfg` in your JAR file.
+
+After adding or modifying the Access Transformer, the Gradle project must be refreshed for the transformations to take effect.
 </TabItem>
 </Tabs>
 

--- a/neogradle/docs/configuration/index.mdx
+++ b/neogradle/docs/configuration/index.mdx
@@ -1,3 +1,6 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ForgeGradle Configurations
 ==========================
 
@@ -6,7 +9,42 @@ ForgeGradle has numerous configurations that can change how the development envi
 Enabling Access Transformers
 ----------------------------
 
-[Access Transformers][at] can widen the visibility or modify the `final` flag of Minecraft classes, methods, and fields. To enable access transformers in the production environment, you can set `accessTransformer` to configuration file in question:
+
+[Access Transformers][at] can widen the visibility or modify the `final` flag of Minecraft classes, methods, and fields.
+
+<Tabs defaultValue="latest">
+<TabItem value="latest" label="Latest">
+To enable Access Transformers in the production environment, you can set `accessTransformers` to the configuration file in question:
+
+```gradle
+minecraft {
+    // ...
+
+    // Add an Access Transformer file relative to the project's directory
+    accessTransformers {
+        file('src/main/resources/META-INF/accesstransformer.cfg')
+
+        // Multiple files can be specified and are applied in order
+        file('src/main/resources/accesstransformer_extras.cfg')
+    }
+}
+```
+
+In production, NeoForge will search for Access Transformer files as specified in `mods.toml`, or at `META-INF/accesstransformer.cfg` if none are specified:
+
+```toml
+[[accessTransformers]]
+file="META-INF/accesstransformer.at"
+
+[[accessTransformers]]
+file="accesstransformer_extras.at"
+```
+
+</TabItem>
+
+
+<TabItem value="7.0.40" label="7.0.40 and older">
+To enable Access Transformers in the production environment, you can set `accessTransformer` to the configuration file in question:
 
 ```gradle
 minecraft {
@@ -18,8 +56,10 @@ minecraft {
 ```
 
 :::caution
-While the access transformer in the development environment can be read from anywhere the user specifies, in production, the file will only be read from `META-INF/accesstransformer.cfg`.
+While the Access Transformer in the development environment can be read from anywhere the user specifies, in production, the file will only be read from `META-INF/accesstransformer.cfg`.
 :::
+</TabItem>
+</Tabs>
 
 Human-Readable Mappings
 -----------------------

--- a/neogradle/docs/configuration/index.mdx
+++ b/neogradle/docs/configuration/index.mdx
@@ -34,10 +34,10 @@ In production, NeoForge will search for Access Transformer files as specified in
 
 ```toml
 [[accessTransformers]]
-file="META-INF/accesstransformer.at"
+file="META-INF/accesstransformer.cfg"
 
 [[accessTransformers]]
-file="accesstransformer_extras.at"
+file="accesstransformer_extras.cfg"
 ```
 
 </TabItem>


### PR DESCRIPTION
This PR updates the docs for Access Transformers to reflect the changes in NeoGradle 7.0.41 ([link to PR](https://github.com/neoforged/NeoGradle/pull/41)) and FancyModLoader 2.0 ([link to PR](https://github.com/neoforged/FancyModLoader/pull/41)). All mentions to Access Transformers show the new format for specifying multiple AT files, as well as the requirement to specify non-default AT file locations in `mods.toml`.

Closes #36.

------------------
Preview URL: https://pr-38.neoforged-docs-previews.pages.dev