### PR TITLE
Fix example code in networking docs

### DIFF
--- a/docs/networking/payload.md
+++ b/docs/networking/payload.md
@@ -41,7 +41,7 @@ We then also need a reader to register this later on, here we can use a custom c
 Finally, we can register this payload with the registrar:
 ```java
 @SubscribeEvent
-public static void register(final RegisterPacketHandlerEvent event) {
+public static void register(final RegisterPayloadHandlerEvent event) {
     final IPayloadRegistrar registrar = event.registrar("mymod");
     registrar.play(MyData.ID, MyData::new, handler -> handler
             .client(ClientPayloadHandler.getInstance()::handleData)

--- a/docs/networking/payload.md
+++ b/docs/networking/payload.md
@@ -3,7 +3,7 @@
 Payloads are a way to send arbitrary data between the client and the server. They are registered using the `IPayloadRegistrar` that can be retrieved for a given namespace from the `RegisterPayloadHandlerEvent` event.
 ```java
 @SubscribeEvent
-public static void register(final RegisterPacketHandlerEvent event) {
+public static void register(final RegisterPayloadHandlerEvent event) {
     final IPayloadRegistrar registrar = event.registrar("mymod");
 }
 ```

--- a/docs/networking/payload.md
+++ b/docs/networking/payload.md
@@ -43,7 +43,7 @@ Finally, we can register this payload with the registrar:
 @SubscribeEvent
 public static void register(final RegisterPacketHandlerEvent event) {
     final IPayloadRegistrar registrar = event.registrar("mymod");
-    registar.play(MyData.ID, MyData::new, handler -> handler
+    registrar.play(MyData.ID, MyData::new, handler -> handler
             .client(ClientPayloadHandler.getInstance()::handleData)
             .server(ServerPayloadHandler.getInstance()::handleData));
 }


### PR DESCRIPTION
This snippet referred to a class that doesn't exist.

I also fixed a typo in a variable name.

------------------
Preview URL: https://pr-43.neoforged-docs-previews.pages.dev