### PR TITLE
Update theming and colours

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -87,7 +87,7 @@ const config = {
       // Replace with your project's social card
       //image: 'img/docusaurus-social-card.jpg',
       navbar: {
-        title: "NeoForged documentation",
+        title: "Homepage",
         logo: {
           alt: "NeoForged Logo",
           src: "img/logo.svg",
@@ -97,7 +97,7 @@ const config = {
             type: "docSidebar",
             sidebarId: "mainSidebar",
             position: "left",
-            label: "Getting Started",
+            label: "NeoForge Documentation",
           },
           {
             type: "docSidebar",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,6 +84,10 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode: {
+        respectPrefersColorScheme: true
+      },
+
       // Replace with your project's social card
       //image: 'img/docusaurus-social-card.jpg',
       navbar: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,8 +1,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 const {themes} = require('prism-react-renderer');
-const lightTheme = themes.github;
-const darkTheme = themes.dracula;
+const lightTheme = themes.oneLight;
+const darkTheme = themes.vsDark;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,6 +15,8 @@
   --ifm-color-primary-lightest: #1f0e73;
   --ifm-code-font-size: 90%;
 
+  --context-divier: #e2e2e3;
+
   --ifm-color-warning-contrast-background: rgb(254, 243, 213);
 
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.125);
@@ -37,6 +39,8 @@ html[data-theme="dark"] {
   --ifm-color-warning-contrast-background: rgba(77, 56, 0, 0.55);
   
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.45);
+
+  --content-divier: #2e2e32;
 }
 
 .menu__caret:before {
@@ -49,4 +53,10 @@ html[data-theme="dark"] {
 
 .hash-link:link {
   text-decoration: none;
+}
+
+h2 {
+  margin: 48px 0 16px;
+  padding-top: 24px;
+  border-top: 1px solid var(--context-divier);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -18,6 +18,7 @@
   --context-divier: #e2e2e3;
 
   --ifm-color-warning-contrast-background: rgb(254, 243, 213);
+  --ifm-code-border-radius: 0.55rem;
 
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.125);
 }
@@ -39,6 +40,7 @@ html[data-theme="dark"] {
   --ifm-color-warning-contrast-background: rgba(77, 56, 0, 0.55);
   
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.45);
+  --ifm-code-background: rgba(255, 255, 255, 0.08);
 
   --content-divier: #2e2e32;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,11 +14,14 @@
   --ifm-color-primary-lighter: #359962;
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  --ifm-color-warning-contrast-background: rgb(254, 243, 213);
+
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.125);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme="dark"] {
+html[data-theme="dark"] {
   --ifm-color-primary: #25c2a0;
   --ifm-color-primary-dark: #21af90;
   --ifm-color-primary-darker: #1fa588;
@@ -26,5 +29,9 @@
   --ifm-color-primary-light: #29d5b0;
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  --ifm-color-secondary-contrast-background: rgba(72, 71, 71, 0.55);
+  --ifm-color-warning-contrast-background: rgba(77, 56, 0, 0.55);
+  
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.5);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,14 +6,14 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
-  --ifm-code-font-size: 95%;
+  --ifm-color-primary: #3819d2;
+  --ifm-color-primary-dark: #3217bd;
+  --ifm-color-primary-darker: #3015b3;
+  --ifm-color-primary-darkest: #271193;
+  --ifm-color-primary-light: #3f1ee4;
+  --ifm-color-primary-lighter: #4829e5;
+  --ifm-color-primary-lightest: #1f0e73;
+  --ifm-code-font-size: 90%;
 
   --ifm-color-warning-contrast-background: rgb(254, 243, 213);
 
@@ -22,16 +22,27 @@
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 html[data-theme="dark"] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary: #0896d4;
+  --ifm-color-primary-dark: #0787bf;
+  --ifm-color-primary-darker: #077fb4;
+  --ifm-color-primary-darkest: #066994;
+  --ifm-color-primary-light: #09a5e9;
+  --ifm-color-primary-lighter: #09acf4;
+  --ifm-color-primary-lightest: #27b8f7;
+
+  --ifm-background-color: #121214;
+  --ifm-background-surface-color: #1b1b1b;
 
   --ifm-color-secondary-contrast-background: rgba(72, 71, 71, 0.55);
   --ifm-color-warning-contrast-background: rgba(77, 56, 0, 0.55);
   
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.5);
+}
+
+.menu__caret:before {
+  background: var(--ifm-menu-link-sublist-icon) 50%/1.75rem;
+}
+
+.menu__link--sublist-caret:after {
+  background: var(--ifm-menu-link-sublist-icon) 50%/1.75rem;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -46,3 +46,7 @@ html[data-theme="dark"] {
 .menu__link--sublist-caret:after {
   background: var(--ifm-menu-link-sublist-icon) 50%/1.75rem;
 }
+
+.hash-link:link {
+  text-decoration: none;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -46,11 +46,11 @@ html[data-theme="dark"] {
 }
 
 .menu__caret:before {
-  background: var(--ifm-menu-link-sublist-icon) 50%/1.75rem;
+  background: var(--ifm-menu-link-sublist-icon) 50%/1.65rem;
 }
 
 .menu__link--sublist-caret:after {
-  background: var(--ifm-menu-link-sublist-icon) 50%/1.75rem;
+  background: var(--ifm-menu-link-sublist-icon) 50%/1.65rem;
 }
 
 .hash-link:link {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,9 +23,9 @@
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 html[data-theme="dark"] {
   --ifm-color-primary: #0896d4;
-  --ifm-color-primary-dark: #0787bf;
-  --ifm-color-primary-darker: #077fb4;
-  --ifm-color-primary-darkest: #066994;
+  --ifm-color-primary-dark: #0891ce;
+  --ifm-color-primary-darker: #088ec9;
+  --ifm-color-primary-darkest: #078ac3;
   --ifm-color-primary-light: #09a5e9;
   --ifm-color-primary-lighter: #09acf4;
   --ifm-color-primary-lightest: #27b8f7;
@@ -36,7 +36,7 @@ html[data-theme="dark"] {
   --ifm-color-secondary-contrast-background: rgba(72, 71, 71, 0.55);
   --ifm-color-warning-contrast-background: rgba(77, 56, 0, 0.55);
   
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.5);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.45);
 }
 
 .menu__caret:before {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -55,6 +55,20 @@ html[data-theme="dark"] {
   text-decoration: none;
 }
 
+a.no-underline {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+.link-card:hover {
+  transform: scale(1.05);
+  border: 1px solid var(--ifm-color-primary-light);
+}
+
+.link-card {
+  transition: transform 450ms ease-in-out;
+}
+
 h2 {
   margin: 48px 0 16px;
   padding-top: 24px;

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -14,7 +14,7 @@ If you would like to contribute to the docs, read [Contributing to the Docs][con
 
 <div class="container">
   <div class="row">
-    <div class="col col--6">
+    <div class="col col--6" style={{padding: '10px'}}>
       <Card
         title="NeoForged Documentation"
         body="Learn how to create your first mod using NeoForge, and discover the vast APIs it provides."
@@ -22,10 +22,10 @@ If you would like to contribute to the docs, read [Contributing to the Docs][con
         linkTitle="Get Started"
       />
     </div>
-    <div class="col col--6">
+    <div class="col col--6" style={{padding: '10px'}}>
       <Card
         title="NeoGradle Documentation"
-        body="NeoGradle is the gradle plugin empowering developers to create mods for NeoForge and develop NeoForge itself."
+        body="Learn about the Gradle plugin empowering developers to create mods for NeoForge and develop NeoForge itself."
         link="/neogradle/docs/"
         linkTitle="Read More"
       />

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -16,7 +16,7 @@ If you would like to contribute to the docs, read [Contributing to the Docs][con
   <div class="row">
     <div class="col col--6" style={{padding: '10px'}}>
       <Card
-        title="NeoForged Documentation"
+        title="NeoForge Documentation"
         body="Learn how to create your first mod using NeoForge, and discover the vast APIs it provides."
         link="/docs/gettingstarted/"
         linkTitle="Get Started"

--- a/src/theme/Card.tsx
+++ b/src/theme/Card.tsx
@@ -3,20 +3,22 @@ import Link from "@docusaurus/Link";
 
 export default function Card(props: any) {
   return (
-    <div className="card">
-      <div className="card__header">
-        <h3>{props.title}</h3>
+    <a href={props.link} className="no-underline">
+      <div className="card link-card">
+        <div className="card__header">
+          <h3>{props.title}</h3>
+        </div>
+        <div className="card__body">
+          <p>
+            {props.body}
+          </p>
+        </div>
+        {(props.link != undefined) ? <div className="card__footer">
+          <Link isNavLink={true} to={props.link} className="button button--secondary button--block">
+            {props.linkTitle}
+          </Link>
+        </div> : ''}
       </div>
-      <div className="card__body">
-        <p>
-          {props.body}
-        </p>
-      </div>
-      {(props.link != undefined) ? <div className="card__footer">
-        <Link isNavLink={true} to={props.link} className="button button--secondary button--block">
-          {props.linkTitle}
-        </Link>
-      </div> : ''}
-    </div>
+    </a>
   );
 }


### PR DESCRIPTION
- Change the prism themes to make code blocks more highlighted (current theme used in dark mode codeblocks does more italic-fication than colouring)
- Improve the contrast of admonitions
- Change background colours to improve contrast.
- Remove text decorations for direct links to sections
- Separate h2 sections with a 1px solid border
- Make the carets a bit smaller (default is 50%/2em)
- Make the homepage cards scale in and out on hover

------------------
Preview URL: https://pr-53.neoforged-docs-previews.pages.dev