### PR TITLE
Update Access Transformers docs

### DIFF
--- a/docs/advanced/accesstransformers.mdx
+++ b/docs/advanced/accesstransformers.mdx
@@ -1,15 +1,13 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Access Transformers
-===================
+# Access Transformers
 
 Access Transformers (ATs for short) allow for widening the visibility and modifying the `final` flags of classes, methods, and fields. They allow modders to access and modify otherwise inaccessible members in classes outside their control.
 
 The [specification document][specs] can be viewed on the NeoForged GitHub.
 
-Adding ATs
-----------
+## Adding ATs
 
 Adding an Access Transformer to your mod project is as simple as adding a single line into your `build.gradle`:
 
@@ -75,13 +73,11 @@ After adding or modifying the Access Transformer, the Gradle project must be ref
 </TabItem>
 </Tabs>
 
-Comments
---------
+## Comments
 
 All text after a `#` until the end of the line will be treated as a comment and will not be parsed.
 
-Access Modifiers
-----------------
+## Access Modifiers
 
 Access modifiers specify to what new member visibility the given target will be transformed to. In decreasing order of visibility:
 
@@ -98,8 +94,7 @@ Directives only modify the method they directly reference; any overriding method
 Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
 :::
 
-Targets and Directives
-----------------------
+## Targets and Directives
 
 ### Classes
 To target classes:
@@ -141,8 +136,7 @@ Also called "descriptors": see the [Java Virtual Machine Specification, SE 8, se
 * `V` - indicates a method returns no value, can only be used at the end of a method descriptor
   * Example: `<method>()V` refers to a method that has no arguments and returns nothing
 
-Examples
---------
+## Examples
 
 ```
 # Makes public the ByteArrayToKeyFunction interface in Crypt

--- a/docs/advanced/accesstransformers.mdx
+++ b/docs/advanced/accesstransformers.mdx
@@ -101,10 +101,6 @@ Examples of methods that can be safely transformed are `private` methods, `final
 Targets and Directives
 ----------------------
 
-:::caution
-When using Access Transformers on Minecraft classes, the SRG name must be used for fields and methods.
-:::
-
 ### Classes
 To target classes:
 ```
@@ -153,15 +149,15 @@ Examples
 public net.minecraft.util.Crypt$ByteArrayToKeyFunction
 
 # Makes protected and removes the final modifier from 'random' in MinecraftServer
-protected-f net.minecraft.server.MinecraftServer f_129758_ #random
+protected-f net.minecraft.server.MinecraftServer random
 
 # Makes public the 'makeExecutor' method in Util,
 # accepting a String and returns an ExecutorService
-public net.minecraft.Util m_137477_(Ljava/lang/String;)Ljava/util/concurrent/ExecutorService; #makeExecutor
+public net.minecraft.Util makeExecutor(Ljava/lang/String;)Ljava/util/concurrent/ExecutorService;
 
 # Makes public the 'leastMostToIntArray' method in UUIDUtil,
 # accepting two longs and returning an int[]
-public net.minecraft.core.UUIDUtil m_235872_(JJ)[I #leastMostToIntArray
+public net.minecraft.core.UUIDUtil leastMostToIntArray(JJ)[I
 ```
 
 [specs]: https://github.com/NeoForged/AccessTransformers/blob/main/FMLAT.md


### PR DESCRIPTION
SRG Names are no longer needed, so I removed the warning about that and updated the examples.

Also moved the headers to the new standard.

------------------
Preview URL: https://pr-56.neoforged-docs-previews.pages.dev