### PR TITLE
Document new mod info localization support

### DIFF
--- a/docs/concepts/internationalization.md
+++ b/docs/concepts/internationalization.md
@@ -37,6 +37,29 @@ By default, `#getDescriptionId` will return `block.` or `item.` prepended to the
 The only purpose of a translation key is internationalization. Do not use them for logic. Use registry names instead.
 :::
 
+Mod metadata
+------------
+
+Historically, A mod's name and description have been defined in [`mods.toml` files][modinfo] without translation support. Starting with Neoforge v20.4.179, translation files can override mod info using the following keys:
+
+| Translation Key | Overrides | Example |
+|:---------------:|:---------:|:--------|
+| `fml.menu.mods.info.displayname.[modid]` | `[[mods]]` -> `displayName` | `fml.menu.mods.info.displayname.examplemod` |
+| `fml.menu.mods.info.description.[modid]` | `[[mods]]` -> `description` | `fml.menu.mods.info.description.examplemod` |
+
+For example, a mod with the id `mymod` could localize its name and description by adding the following lines to a language file:
+
+```js
+{
+  "fml.menu.mods.info.displayname.mymod": "My Mod",
+  "fml.menu.mods.info.description.mymod": "My Mod is super cool and localized!"
+}
+```
+
+:::warning
+It is still recommended to define `displayName` and `description` in your [`mods.toml` file][modinfo], because the localization keys are not guaranteed to be supported everywhere. This is especially true for third-party tools.
+:::
+
 Localization methods
 --------------------
 
@@ -67,5 +90,6 @@ Read [components] for more details.
 
 [langs]: https://minecraft.wiki/w/Language#Languages
 [converter]: https://tterrag.com/lang2json/
+[modinfo]: ../gettingstarted/modfiles.md#mod-specific-properties
 [formatting]: ../misc/components.md#text-formatting
 [components]: ../misc/components.md

--- a/docs/concepts/internationalization.md
+++ b/docs/concepts/internationalization.md
@@ -1,5 +1,4 @@
-Internationalization and Localization
-=====================================
+# Internationalization and Localization
 
 Internationalization, i18n for short, is a way of designing code so that it requires no changes to be adapted for various languages. Localization is the process of adapting displayed text to the user's language.
 
@@ -7,8 +6,7 @@ I18n is implemented using _translation keys_. A translation key is a string that
 
 Localization will happen in the game's locale. In a Minecraft client the locale is specified by the language settings. On a dedicated server, the only supported locale is `en_us`. A list of available locales can be found on the [Minecraft Wiki][langs].
 
-Language files
---------------
+## Language files
 
 Language files are located by `assets/[namespace]/lang/[locale].json` (e.g. all US English translations provided by `examplemod` would be within `assets/examplemod/lang/en_us.json`). The file format is simply a json map from translation keys to values. The file must be encoded in UTF-8. Old .lang files can be converted to json using a [converter][converter].
 
@@ -20,8 +18,7 @@ Language files are located by `assets/[namespace]/lang/[locale].json` (e.g. all 
 }
 ```
 
-Usage with Blocks and Items
----------------------------
+## Usage with Blocks and Items
 
 Block, Item and a few other Minecraft classes have built-in translation keys used to display their names. These translation keys are specified by overriding `#getDescriptionId`. Item also has `#getDescriptionId(ItemStack)` which can be overridden to provide different translation keys depending on ItemStack NBT.
 
@@ -37,8 +34,7 @@ By default, `#getDescriptionId` will return `block.` or `item.` prepended to the
 The only purpose of a translation key is internationalization. Do not use them for logic. Use registry names instead.
 :::
 
-Mod metadata
-------------
+## Mod metadata
 
 Historically, A mod's name and description have been defined in [`mods.toml` files][modinfo] without translation support. Starting with Neoforge v20.4.179, translation files can override mod info using the following keys:
 
@@ -60,8 +56,7 @@ For example, a mod with the id `mymod` could localize its name and description b
 It is still recommended to define `displayName` and `description` in your [`mods.toml` file][modinfo], because the localization keys are not guaranteed to be supported everywhere. This is especially true for third-party tools.
 :::
 
-Localization methods
---------------------
+## Localization methods
 
 :::caution
 A common issue is having the server localize for clients. The server can only localize in its own locale, which does not necessarily match the locale of connected clients.

--- a/docs/gettingstarted/modfiles.md
+++ b/docs/gettingstarted/modfiles.md
@@ -109,6 +109,10 @@ modId = "examplemod2"
 | `displayURL`    | string  |          *nothing*          |                                                                                                       A URL to the display page of the mod shown on the mod list screen.                                                                                                       | `displayURL="https://neoforged.net/"`                           |
 | `displayTest`   | string  |      `"MATCH_VERSION"`      |                                                                                                                                  See [sides].                                                                                                                                  | `displayTest="NONE"`                                            |
 
+:::note
+Some properties (`displayName` and `description`) can also be localized using language files. See [Internationalization and Localization][i18n] for more detail.
+:::
+
 #### Features
 
 The features system allows mods to demand that certain settings, software, or hardware are available when loading the system. When a feature is not satisfied, mod loading will fail, informing the user about the requirement. Currently, NeoForge provides the following features:
@@ -166,6 +170,7 @@ There must be a 1-to-1 matching of mods in the `mods.toml` file and `@Mod` entry
 [events]: ../concepts/events.md
 [features]: #features
 [group]: #the-group-id
+[i18n]: ../concepts/internationalization.md#mod-metadata
 [javafml]: #javafml-and-mod
 [jei]: https://www.curseforge.com/minecraft/mc-mods/jei
 [lowcodefml]: #lowcodefml


### PR DESCRIPTION
Adds initial documentation for the new translatable mod info support [added in `v20.4.179`](https://github.com/neoforged/NeoForge/pull/649).

------------------
Preview URL: https://pr-57.neoforged-docs-previews.pages.dev