### PR TITLE
Correct the model loader

### DIFF
--- a/docs/rendering/modelloaders/index.md
+++ b/docs/rendering/modelloaders/index.md
@@ -15,7 +15,7 @@ Forge adds a loader for the `.obj` file format. To use these models, the JSON mu
 ```js
 {
   // Add the following line on the same level as a 'model' declaration
-  "loader": "forge:obj",
+  "loader": "neoforge:obj",
   "flip_v": true,
   "model": "examplemod:models/block/model.obj",
   "textures": {


### PR DESCRIPTION
The identity of the OBJ model loader inside the codebase has been changed from "forge:obj" into "neoforge:obj" but not yet for the documentation.

Discovered by chance when handling a weird model loading issue during my developing NeoForge mod.

------------------
Preview URL: https://pr-61.neoforged-docs-previews.pages.dev