### PR TITLE
Fix improper admonition

### DIFF
--- a/docs/datastorage/codecs.md
+++ b/docs/datastorage/codecs.md
@@ -158,7 +158,7 @@ An `Instance` can define up to 16 fields using `#group`. Each field must be an a
 
 A field can be created from a `Codec` using `#fieldOf`, if the field is required, or `#optionalFieldOf`, if the field is wrapped in an `Optional` or defaulted. Either method requires a string containing the name of the field in the encoded object. The getter used to encode the field can then be set using `#forGetter`, taking in a function which given the object, returns the field data.
 
-:::warn
+:::warning
 `#optionalFieldOf` will throw an error if there is an element that throws an error when parsing. If the error should be consumed, use `#lenientOptionalFieldOf` instead.
 :::
 


### PR DESCRIPTION
`warn` is not a valid admonition, so it has been changed to `warning`.

------------------
Preview URL: https://pr-74.neoforged-docs-previews.pages.dev