### PR TITLE
Fix recursive codec example

### DIFF
--- a/docs/datastorage/codecs.md
+++ b/docs/datastorage/codecs.md
@@ -491,7 +491,7 @@ public static final Codec<RecursiveObject> RECURSIVE_CODEC = Codec.recursive(
     RecursiveObject.class.getSimpleName(), // This is for the toString method
     recursedCodec -> RecordCodecBuilder.create(instance -> instance.group(
         recursedCodec.optionalFieldOf("inner").forGetter(RecursiveObject::inner)
-    ), RecursiveObject::new)
+    ).apply(instance, RecursiveObject::new))
 );
 ```
 


### PR DESCRIPTION
To construct a record codec after grouping, the `apply` method must be called supplying the instance, not as a second parameter of the `create` function. This properly constructs the example.