### PR TITLE
Depluralize Registry and Tag Folders

### DIFF
--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -190,8 +190,8 @@ A datapack registry (also known as a dynamic registry or, after its main use cas
 
 Datapack registries allow their contents to be specified in JSON files. This means that no code (other than [datagen][datagen] if you don't want to write the JSON files yourself) is necessary. Every datapack registry has a [`Codec`][codec] associated with it, which is used for serialization, and each registry's id determines its datapack path:
 
-- Minecraft's datapack registries use the format `data/yourmodid/registrypath` (for example `data/yourmodid/worldgen/biomes`, where `worldgen/biomes` is the registry path).
-- All other datapack registries (NeoForge or modded) use the format `data/yourmodid/registrynamespace/registrypath` (for example `data/yourmodid/neoforge/loot_modifiers`, where `neoforge` is the registry namespace and `loot_modifiers` is the registry path).
+- Minecraft's datapack registries use the format `data/yourmodid/registrypath` (for example `data/yourmodid/worldgen/biome`, where `worldgen/biome` is the registry path).
+- All other datapack registries (NeoForge or modded) use the format `data/yourmodid/registrynamespace/registrypath` (for example `data/yourmodid/neoforge/biome_modifier`, where `neoforge` is the registry namespace and `biome_modifier` is the registry path).
 
 Datapack registries can be obtained from a `RegistryAccess`. This `RegistryAccess` can be retrieved by calling `ServerLevel#registryAccess()` if on the server, or `Minecraft.getInstance().getConnection()#registryAccess()` if on the client (the latter only works if you are actually connected to a world, as otherwise the connection will be null). The result of these calls can then be used like any other registry to get specific elements, or to iterate over the contents.
 

--- a/docs/misc/gametest.mdx
+++ b/docs/misc/gametest.mdx
@@ -164,7 +164,7 @@ The value supplied to `GameTestHolder#value` and `GameTest#templateNamespace` ca
 
 ## Structure Templates
 
-Game Tests are performed within scenes loaded by structures, or templates. All templates define the dimensions of the scene and the initial data (blocks and entities) that will be loaded. The template must be stored as an `.nbt` file within `data/<namespace>/structures`.
+Game Tests are performed within scenes loaded by structures, or templates. All templates define the dimensions of the scene and the initial data (blocks and entities) that will be loaded. The template must be stored as an `.nbt` file within `data/<namespace>/structure`.
 
 :::tip
 A structure template can be created and saved using a structure block.

--- a/docs/misc/resourcelocation.md
+++ b/docs/misc/resourcelocation.md
@@ -24,7 +24,7 @@ Some places, for example registries, use `ResourceLocation`s directly. Some othe
 
 - `ResourceLocation`s are used as identifiers for GUI background. For example, the furnace GUI uses the resource location `minecraft:textures/gui/container/furnace.png`. This maps to the file `assets/minecraft/textures/gui/container/furnace.png` on disk. Note that the `.png` suffix is required in this resource location.
 - `ResourceLocation`s are used as identifiers for block models. For example, the block model of dirt uses the resource location `minecraft:block/dirt`. This maps to the file `assets/minecraft/models/block/dirt.json` on disk. Note that the `.json` suffix is not required here. Note as well that this resource location automatically maps into the `models` subfolder.
-- `ResourceLocation`s are used as identifiers for recipes. For example, the iron block crafting recipe uses the resource location `minecraft:iron_block`. This maps to the file `data/minecraft/recipes/iron_block.json` on disk. Note that the `.json` suffix is not required here. Note as well that this resource location automatically maps into the `recipes` subfolder.
+- `ResourceLocation`s are used as identifiers for recipes. For example, the iron block crafting recipe uses the resource location `minecraft:iron_block`. This maps to the file `data/minecraft/recipe/iron_block.json` on disk. Note that the `.json` suffix is not required here. Note as well that this resource location automatically maps into the `recipe` subfolder.
 
 Whether the `ResourceLocation` expects a file suffix, or what exactly the resource location resolves to, depends on the use case.
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -34,14 +34,14 @@ Data packs may contain folders with files affecting the following things:
 
 | Folder name                                                           | Contents                     |
 |-----------------------------------------------------------------------|------------------------------|
-| `advancements`                                                        | [Advancements][advancements] |
+| `advancement`                                                         | [Advancements][advancements] |
 | `damage_type`                                                         | Damage types                 |
-| `loot_tables`                                                         | [Loot tables][loottables]    |
-| `recipes`                                                             | [Recipes][recipes]           |
-| `structures`                                                          | Structures                   |
+| `loot_table`                                                          | [Loot tables][loottables]    |
+| `recipe`                                                              | [Recipes][recipes]           |
+| `structure`                                                           | Structures                   |
 | `tags`                                                                | [Tags][tags]                 |
-| `dimension`, `dimension_type`, `worldgen`, `neoforge/biome_modifiers` | Worldgen files               |
-| `neoforge/global_loot_modifiers`                                      | [Global loot modifiers][glm] |
+| `dimension`, `dimension_type`, `worldgen`, `neoforge/biome_modifier`  | Worldgen files               |
+| `neoforge/loot_modifiers`                                             | [Global loot modifiers][glm] |
 
 Additionally, they may also contain subfolders for some systems that integrate with commands. These systems are rarely used in conjunction with mods, but worth mentioning regardless:
 

--- a/docs/resources/server/loottables.md
+++ b/docs/resources/server/loottables.md
@@ -8,7 +8,7 @@ Most loot tables within vanilla are data driven via JSON. This means that a mod 
 
 ## Using a Loot Table
 
-A loot table is referenced by its `ResourceKey<LootTable>` which points to `data/<namespace>/loot_tables/<path>.json`. The `LootTable` associated with the reference can be obtained using `ReloadableServerRegistries.Holder#getLootTable`, where `ReloadableServerRegistries.Holder` can be obtained via `MinecraftServer#reloadableRegistries`.
+A loot table is referenced by its `ResourceKey<LootTable>` which points to `data/<namespace>/loot_table/<path>.json`. The `LootTable` associated with the reference can be obtained using `ReloadableServerRegistries.Holder#getLootTable`, where `ReloadableServerRegistries.Holder` can be obtained via `MinecraftServer#reloadableRegistries`.
 
 A loot table is always generated with given parameters. The `LootParams` contains the level the table is generated in, luck for better generation, the `LootContextParam`s which define scenario context, and any dynamic information that should occur on activation. The `LootParams` can be created using the constructor of the `LootParams.Builder` builder, and built via `LootParams.Builder#create` by passing in the `LootContextParamSet`.
 

--- a/docs/resources/server/recipes/index.md
+++ b/docs/resources/server/recipes/index.md
@@ -6,7 +6,7 @@ Recipes are a way to transform some number of objects into other objects within 
 
 Most recipe implementations within vanilla are data driven via JSON. This means that a mod is not necessary to create a new recipe, only a [Data pack][datapack]. A full list on how to create and put these recipes within the mod's `resources` folder can be found on the [Minecraft Wiki][wiki].
 
-A recipe can be obtained within the Recipe Book as a reward for completing an [advancement][advancement]. Recipe advancements always have `minecraft:recipes/root` as their parent, to not to appear on the advancement screen. The default criteria to gain the recipe advancement is a check if the user has unlocked the recipe from using it once or receiving it through a command like `/recipe`:
+A recipe can be obtained within the Recipe Book as a reward for completing an [advancement][advancement]. Recipe advancements always have `minecraft:recipe/root` as their parent, to not to appear on the advancement screen. The default criteria to gain the recipe advancement is a check if the user has unlocked the recipe from using it once or receiving it through a command like `/recipe`:
 
 ```json5
 // Within some recipe advancement json


### PR DESCRIPTION
Depluralizes all registry and tag folders mentioned. Also fixes an example where `loot_modifiers` is not a datapack registry.

------------------
Preview URL: https://pr-126.neoforged-docs-previews.pages.dev