### PR TITLE
Fix small typo in Semantic Versioning section

### DIFF
--- a/docs/gettingstarted/versioning.md
+++ b/docs/gettingstarted/versioning.md
@@ -38,7 +38,7 @@ Versioning systems are suggestions, rather than strictly enforced rules. This is
 
 ### Semantic Versioning
 
-Semantic versioning ("semver") consists of three parts: `major.minor.patch`. The major version is bumped when major changes are made to the codebase, which usually correlates with major new features and bugfixes. The minor version is bumped when minor features are introduced, and patch bumps happen when an update only includes bugs.
+Semantic versioning ("semver") consists of three parts: `major.minor.patch`. The major version is bumped when major changes are made to the codebase, which usually correlates with major new features and bugfixes. The minor version is bumped when minor features are introduced, and patch bumps happen when an update only includes bug-fixes.
 
 It is generally agreed upon that any version `0.x.x` is a development version, and with the first (full) release, the version should be bumped to `1.0.0`.
 


### PR DESCRIPTION
Minor typo fix: bugs -> bug-fixes.