### PR TITLE
Fix incorrect reference to `Attribute`

### DIFF
--- a/docs/items/mobeffects.md
+++ b/docs/items/mobeffects.md
@@ -69,7 +69,7 @@ The `MobEffect` class also provides default functionality for adding attribute m
 
 ```java
 public static final Supplier<MyMobEffect> MY_MOB_EFFECT = MOB_EFFECTS.register("my_mob_effect", () -> new MyMobEffect(...)
-        .addAttributeModifier(Attribute.ATTACK_DAMAGE, ResourceLocation.fromNamespaceAndPath("examplemod", "effect.strength"), 2.0, AttributeModifier.Operation.ADD_VALUE)
+        .addAttributeModifier(Attributes.ATTACK_DAMAGE, ResourceLocation.fromNamespaceAndPath("examplemod", "effect.strength"), 2.0, AttributeModifier.Operation.ADD_VALUE)
 );
 ```
 


### PR DESCRIPTION
Fixes a typo in the Mob Effects article that incorrectly references `Attribute` instead of `Attributes`.

------------------
Preview URL: https://pr-153.neoforged-docs-previews.pages.dev