### PR TITLE
Biome Modifier documentation

### DIFF
--- a/docs/advanced/_category_.json
+++ b/docs/advanced/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Advanced Topics",
-  "position": 11
+  "position": 12
 }

--- a/docs/legacy/_category_.json
+++ b/docs/legacy/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Legacy",
-  "position": 13
+  "position": 14
 }

--- a/docs/misc/_category_.json
+++ b/docs/misc/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Miscellaneous",
-  "position": 12
+  "position": 13
 }

--- a/docs/networking/_category_.json
+++ b/docs/networking/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Networking",
-  "position": 10
+  "position": 11
 }

--- a/docs/worldgen/_category_.json
+++ b/docs/worldgen/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Worldgen",
+  "position": 10
+}

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -4,7 +4,7 @@ Biome Modifiers are a data-driven system that allows for changing many aspects o
 
 For players and pack makers, you will want to see the '[Applying Biome Modifiers](#Applying-Biome-Modifiers)' section and '[Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)' section.
 
-For modders looking to do basic goals, you will want to see the '[Applying Biome Modifiers](#Applying-Biome-Modifiers)' section, '[Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)' section, and possibly the '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)' section if you prefer to datagen.
+For modders looking to do simple additions or removals, you will want to see the '[Applying Biome Modifiers](#Applying-Biome-Modifiers)' section, '[Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)' section, and possibly the '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)' section if you prefer to datagen.
 
 For modders looking to do advanced custom Biome Modifiers, check out the '[Applying Biome Modifiers](#Applying-Biome-Modifiers)' section and '[Creating Custom Biome Modifiers](#Creating-Custom-Biome-Modifiers)' section.
 

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -684,8 +684,6 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 This will then result in the following JSON being created:
 
-This will then result in the following JSON being created:
-
 ```json5
 // In data/examplemod/neoforge/biome_modifier/example_modifier.json
 {

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -1,3 +1,6 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Biome Modifiers
 
 Biome Modifiers are a data-driven system that allows for changing many aspects of a biome. Ranging from injecting or removing PlacedFeatures, adding or deleting mob spawns, changing the climate, and adjusting foliage and water color. NeoForge provides several default Biome Modifiers that covers the majority of use cases for both players and modders.

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -456,7 +456,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 ### Add Legacy Carvers
 
-This biome modifier type allows adding carver caves and ravines to biomes. These are what was used for cave generation before the Caves and Cliffs update. It CANNOT add noise caves to biomes, because noise caves are baked into the dimension's noise settings system and not actually tied to biomes.
+This biome modifier type allows adding carver caves and ravines to biomes. These are what was used for cave generation before the Caves and Cliffs update. It CANNOT add noise caves to biomes, because noise caves are a part of certain noise-based chunk generator systems and not actually tied to biomes.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -3,11 +3,11 @@ import TabItem from '@theme/TabItem';
 
 # Biome Modifiers
 
-Biome Modifiers are a data-driven system that allows for changing many aspects of a biome. Ranging from injecting or removing PlacedFeatures, adding or deleting mob spawns, changing the climate, and adjusting foliage and water color. NeoForge provides several default Biome Modifiers that covers the majority of use cases for both players and modders.
+Biome Modifiers are a data-driven system that allows for changing many aspects of a biome, including the ability to inject or remove PlacedFeatures, add or remove mob spawns, change the climate, and adjust foliage and water color. NeoForge provides several default biome modifiers that cover the majority of use cases for both players and modders.
 
 ### Recommended Section To Read:
 
-- Players or Pack Makers:
+- Players or pack developers:
   - [Applying Biome Modifiers](#Applying-Biome-Modifiers)
   - [Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)
 
@@ -24,19 +24,19 @@ Biome Modifiers are a data-driven system that allows for changing many aspects o
   - [Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)
 
 
-## Applying Biome Modifiers:
+## Applying Biome Modifiers
 
 To have NeoForge load a Biome Modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a Datapack. Then once NeoForge loads the Biome Modifier, it'll read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing Biome Modifiers from mods can be overridden by Datapacks having a new JSON file at the exact same location and name.
 
 The JSON file can be created by hand following the examples in the '[Built-in NeoForge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)' section or be datagenned as shown in the '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)' section.
 
-## Builtin Neoforge Biome Modifiers:
+## Built-in Biome Modifiers
 
-These Biome Modifiers are registered by NeoForge for anyone to use. The JSON example and the Datagen code are provided as well as a brief explanation on what the modifier does.
+These biome modifiers are registered by NeoForge for anyone to use.
 
 ### None
 
-This Biome Modifier has no operation and will do no modification. Pack makers and players can use this in a Datapack to disable mods' Biome Modifiers by overriding their Biome Modifier jsons with the below.
+This biome modifier has no operation and will do no modification. Pack makers and players can use this in a datapack to disable mods' biome modifiers by overriding their biome modifier JSONs with the JSON below.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
@@ -51,21 +51,18 @@ This Biome Modifier has no operation and will do no modification. Pack makers an
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for Datapack registry objects
-public static final ResourceKey<BiomeModifier> NO_OP_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "no_op_example") // The registry name
-    );
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> NO_OP_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "no_op_example") // The registry name
+);
 
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    
-    // Register the Biome Modifiers
+    // Register the biome modifiers.
     bootstrap.register(NO_OP_EXAMPLE, NoneBiomeModifier.INSTANCE);
-})
+});
 ```
 
   </TabItem>
@@ -73,28 +70,25 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 ### Add Features
 
-This Biome Modifier type adds features (such as trees or ores) to biomes so that they can spawn during world generation. The modifier takes in the `Biome` id or tag of the biomes the features are added to, a `PlacedFeature` id or tag of the features to add to the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps) the features will be generated within.
+This biome modifier type adds `PlacedFeature`s (such as trees or ores) to biomes so that they can spawn during world generation. The modifier takes in the biome id or tag of the biomes the features are added to, a `PlacedFeature` id or tag to add to the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps) the features will be generated within.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
 
 ```json5
 {
-    "type": "neoforge:add_features",
-
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#namespace:your_biome_tag",
-
-    // Can either be an id "examplemod:add_features_example"
-    // List of ids ["examplemod:add_features_example", "minecraft:ice_spike", ...]
-    // Or a tag "#examplemod:placed_feature_tag"
-    "features": "namespace:your_feature",
-
-    // See GenerationStep.Decoration enum in code for a list of valid enum names.
-    // The Decoration step section further down also has the list of values for reference.
-    "step": "underground_ores"
+  "type": "neoforge:add_features",
+  // Can either be a biome id, such as "minecraft:plains",
+  // or a list of biome ids, such as ["minecraft:plains", "minecraft:badlands", ...],
+  // or a biome tag, such as "#c:is_overworld".
+  "biomes": "#namespace:your_biome_tag",
+  // Can either be a placed feature id, such as "examplemod:add_features_example",
+  // or a list of placed feature ids, such as ["examplemod:add_features_example", minecraft:ice_spike", ...],
+  // or a placed feature tag, such as "#examplemod:placed_feature_tag".
+  "features": "namespace:your_feature",
+  // See the GenerationStep.Decoration enum in code for a list of valid enum names.
+  // The decoration step section further down also has the list of values for reference.
+  "step": "underground_ores"
 }
 ```
 
@@ -102,27 +96,22 @@ This Biome Modifier type adds features (such as trees or ores) to biomes so that
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Assume we have some PlacedFeature EXAMPLE_PLACED_FEATURE
+// Assume we have some PlacedFeature named EXAMPLE_PLACED_FEATURE.
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> ADD_FEATURES_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_features_example") // The registry name
+);
 
-// Define keys for Datapack registry objects
-
-public static final ResourceKey<BiomeModifier> ADD_FEATURES_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_features_example") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
     HolderGetter<PlacedFeature> placedFeatures = bootstrap.lookup(Registries.PLACED_FEATURE);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(ADD_FEATURES_EXAMPLE,
         new AddFeaturesBiomeModifier(
             // The biome(s) to generate within
@@ -141,14 +130,14 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 
 :::warning
-- Avoid using Biome Modifiers to add vanilla placed features to biomes, as this may cause a feature cycle violation (the game will crash if two biomes have the same two features in their feature lists but in different orders within same GenerationStep). Placed features can be referenced in biome jsons or added via Biome Modifiers, but should not be used in both. Make a new copy of a vanilla Placed Feature is ideal for adding it safely to biomes.
+Care should be taken when adding vanilla `PlacedFeature`s to biomes, as doing so may cause what is known as a feature cycle violation (two biomes having the same two features in their feature lists, but in different orders within the same `GenerationStep`), leading to a crash. For similar reasons, you should not use the same `PlacedFeature` in more than one biome modifier.
 
-- Avoid adding the same placed feature with more than one Biome Modifier, as this can cause feature cycle violations.
+Vanilla `PlacedFeature`s can be referenced in biome JSONs or added via biome modifiers, but should not be used in both. If you still need to add them this way, making a copy of the vanilla `PlacedFeature` is the easiest solution to avoid these problems.
 :::
 
 ### Remove Features
 
-This Biome Modifier type removes features (such as trees or ores) from biomes so that they will no longer spawn during world generation. The modifier takes in the `Biome` id or tag of the biomes the features are removed from, a `PlacedFeature` id or tag of the features to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)s that the features will be removed from.
+This biome modifier type removes features (such as trees or ores) from biomes so that they will no longer spawn during world generation. The modifier takes in the biome id or tag of the biomes the features are removed from, a `PlacedFeature` id or tag to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)s that the features will be removed from.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
@@ -156,21 +145,19 @@ This Biome Modifier type removes features (such as trees or ores) from biomes so
 ```json5
 {
     "type": "neoforge:remove_features",
-
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
+    // Can either be a biome id, such as "minecraft:plains",
+    // or a list of biome ids, such as ["minecraft:plains", "minecraft:badlands", ...],
+    // or a biome tag, such as "#c:is_overworld".
     "biomes": "#namespace:your_biome_tag",
-
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
+    // Can either be a placed feature id, such as "examplemod:add_features_example",
+    // or a list of placed feature ids, such as ["examplemod:add_features_example", "minecraft:ice_spike", ...],
+    // or a placed feature tag, such as "#examplemod:placed_feature_tag".
     "features": "namespace:problematic_feature",
-  
-    // Optional field specifying a GenerationStep or list of GenerationSteps to remove features from, defaults to all if not specified.
-    // See GenerationStep.Decoration enum in code for a list of valid enum names.
-    // The Decoration step section further down also has the list of values for reference.
-    "steps": [ "underground_ores", "underground_ores" ] 
+    // Optional field specifying a GenerationStep, or a list of GenerationSteps, to remove features from.
+    // If omitted, defaults to all GenerationSteps.
+    // See the GenerationStep.Decoration enum in code for a list of valid enum names.
+    // The decoration step section further down also has the list of values for reference.
+    "steps": ["underground_ores", "underground_decoration"]
 }
 ```
 
@@ -178,25 +165,21 @@ This Biome Modifier type removes features (such as trees or ores) from biomes so
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for Datapack registry objects
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> REMOVE_FEATURES_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_features_example") // The registry name
+);
 
-public static final ResourceKey<BiomeModifier> REMOVE_FEATURES_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_features_example") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
     HolderGetter<PlacedFeature> placedFeatures = bootstrap.lookup(Registries.PLACED_FEATURE);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(REMOVE_FEATURES_EXAMPLE,
         new RemoveFeaturesBiomeModifier(
             // The biome(s) to remove from
@@ -210,7 +193,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
             )
         )
     );
-})
+});
 ```
 
   </TabItem>
@@ -221,35 +204,35 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 This Biome Modifier type adds mob spawns to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are added to and the `SpawnerData` of the mobs to add. Each `SpawnerData` contains the mob id, the spawn weight, and the minimum/maximum number of mobs to spawn at a given time.
 
-**NOTE:** If you are a modder adding a new mob, make sure the mob has a spawn restriction registered to RegisterSpawnPlacementsEvent event. If you do not register a spawn restriction, your mob could spawn in mid-air, fall and die. Spawn restrictions are used to make mobs spawn on surfaces or in water safely.
+:::note
+If you are a modder adding a new entity, make sure the entity has a spawn restriction registered to `RegisterSpawnPlacementsEvent`. If you do not register a spawn restriction, your entity could spawn in mid-air, fall and die. Spawn restrictions are used to make entities spawn on surfaces or in water safely.
+:::
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
 
 ```json5
 {
-    "type": "neoforge:add_spawns",
-
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#namespace:biome_tag", 
-  
-    // Can be either a single object or a list of objects
-    "spawners": [
-      {
-        "type": "namespace:entity_type", // Type of mob to spawn
-        "weight": 100, // int, spawn weighting
-        "minCount": 1, // int, minimum pack size
-        "maxCount": 4 // int, maximum pack size
-      },
-      {
-        "type": "minecraft:ghast",
-        "weight": 1,
-        "minCount": 5,
-        "maxCount": 10
-      }
-    ]
+  "type": "neoforge:add_spawns",
+  // Can either be a biome id, such as "minecraft:plains",
+  // or a list of biome ids, such as ["minecraft:plains", "minecraft:badlands", ...],
+  // or a biome tag, such as "#c:is_overworld".
+  "biomes": "#namespace:biome_tag",
+  // Can be either a single object or a list of objects.
+  "spawners": [
+    {
+      "type": "namespace:entity_type", // The id of the entity type to spawn
+      "weight": 100, // int, spawn weight
+      "minCount": 1, // int, minimum group size
+      "maxCount": 4 // int, maximum group size
+    },
+    {
+      "type": "minecraft:ghast",
+      "weight": 1,
+      "minCount": 5,
+      "maxCount": 10
+    }
+  ]
 }
 ```
 
@@ -257,26 +240,21 @@ This Biome Modifier type adds mob spawns to biomes. The modifier takes in the `B
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Assume we have some EntityType EXAMPLE_ENTITY
+// Assume we have some EntityType<?> named EXAMPLE_ENTITY.
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> ADD_SPAWNS_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_spawns_example") // The registry name
+);
 
-// Define keys for Datapack registry objects
-
-public static final ResourceKey<BiomeModifier> ADD_SPAWNS_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_spawns_example") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(ADD_SPAWNS_EXAMPLE,
         new AddSpawnsBiomeModifier(
             // The biome(s) to spawn the mobs within
@@ -288,7 +266,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
             )
         )
     );
-})
+});
 ```
 
   </TabItem>
@@ -297,24 +275,22 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 ### Remove Spawns
 
-This Biome Modifier type removes mob spawns from biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are removed from and the `EntityType` id or tag of the mobs to remove.
+This biome modifier type removes entity spawns from biomes. The modifier takes in the biome id or tag of the biomes the entity spawns are removed from, and the `EntityType` id or tag of the entities to remove.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
 
 ```json5
 {
-    "type": "neoforge:remove_spawns",
-
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#namespace:biome_tag",
-
-    // Can either be an id "minecraft:ghast"
-    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
-    // Or a tag "#minecraft:skeletons"
-    "entity_types": "#namespace:entitytype_tag"
+  "type": "neoforge:remove_spawns",
+  // Can either be a biome id, such as "minecraft:plains",
+  // or a list of biome ids, such as ["minecraft:plains", "minecraft:badlands", ...],
+  // or a biome tag, such as "#c:is_overworld".
+  "biomes": "#namespace:biome_tag",
+  // Can either be an entity type id, such as "minecraft:ghast",
+  // or a list of entity type ids, such as ["minecraft:ghast", "minecraft:skeleton", ...],
+  // or an entity type tag, such as "#minecraft:skeletons".
+  "entity_types": "#namespace:entitytype_tag"
 }
 ```
 
@@ -322,25 +298,21 @@ This Biome Modifier type removes mob spawns from biomes. The modifier takes in t
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for Datapack registry objects
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> REMOVE_SPAWNS_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_spawns_example") // The registry name
+);
 
-public static final ResourceKey<BiomeModifier> REMOVE_SPAWNS_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_spawns_example") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
     HolderGetter<EntityType<?>> entities = bootstrap.lookup(Registries.ENTITY_TYPE);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(REMOVE_SPAWNS_EXAMPLE,
         new RemoveSpawnsBiomeModifier(
             // The biome(s) to remove the spawns from
@@ -349,7 +321,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
             entities.getOrThrow(EntityTypeTags.SKELETONS)
         )
     );
-})
+});
 ```
 
   </TabItem>
@@ -358,32 +330,34 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 ### Add Spawn Costs
 
-Allows for adding new Spawn Costs to biomes. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. It works by having the entities give off a `charge` that surrounds them and adds up with other entity's `charge`. Then when spawning, it looks for a spot where the total `charge` field at the location multiplied by the spawning entity's `charge` value is less than the spawning entity's `energy_budget`. This is an advanced way of spawning mobs so it is a good idea to reference the Soul Sand Valley Biome for existing values to borrow.
+Allows for adding new spawn costs to biomes. Spawn costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. It works by having the entities give off a `charge` that surrounds them and adds up with other entities' `charge`. When spawning a new entity, the spawning algorithm looks for a spot where the total `charge` field at the location multiplied by the spawning entity's `charge` value is less than the spawning entity's `energy_budget`. This is an advanced way of spawning mobs, so it is a good idea to reference the Soul Sand Valley biome (which is the most prominent user of this system) for existing values to borrow.
 
-The modifier takes in the `Biome` id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the mobs to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the mob. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based upon the charge provided for each entity spawned.
+The modifier takes in the biome id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the entity types to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the entity. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based on the charge provided for each entity spawned.
 
-**NOTE:** If you are a modder adding a new mob, make sure the mob has a spawn restriction registered to RegisterSpawnPlacementsEvent event.
+:::note
+If you are a modder adding a new entity, make sure the entity has a spawn restriction registered to `RegisterSpawnPlacementsEvent`.
+:::
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
 
 ```json5
 {
-    "type": "neoforge:add_spawn_costs",
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#c:is_overworld",
-    // Can either be an id "minecraft:ghast"
-    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
-    // Or a tag "#minecraft:skeletons"
-    "entity_types": "#minecraft:skeletons",
-    "spawn_cost": {
-        // The energy budget
-        "energy_budget": 1.0,
-        // The amount of charge each entity takes up from the budget
-        "charge": 0.1
-    }
+  "type": "neoforge:add_spawn_costs",
+  // Can either be a biome id, such as "minecraft:plains",
+  // or a list of biome ids, such as ["minecraft:plains", "minecraft:badlands", ...],
+  // or a biome tag, such as "#c:is_overworld".
+  "biomes": "#namespace:biome_tag",
+  // Can either be an entity type id, such as "minecraft:ghast",
+  // or a list of entity type ids, such as ["minecraft:ghast", "minecraft:skeleton", ...],
+  // or an entity type tag, such as "#minecraft:skeletons".
+  "entity_types": "#minecraft:skeletons",
+  "spawn_cost": {
+    // The energy budget
+    "energy_budget": 1.0,
+    // The amount of charge each entity takes up from the budget
+    "charge": 0.1
+  }
 }
 ```
 
@@ -391,25 +365,21 @@ The modifier takes in the `Biome` id or tag of the biomes the spawn costs are ad
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for Datapack registry objects
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> ADD_SPAWN_COSTS_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_spawn_costs_example") // The registry name
+);
 
-public static final ResourceKey<BiomeModifier> ADD_SPAWN_COSTS_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_spawn_costs_example") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
     HolderGetter<EntityType<?>> entities = bootstrap.lookup(Registries.ENTITY_TYPE);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(ADD_SPAWN_COSTS_EXAMPLE,
         new AddSpawnCostsBiomeModifier(
             // The biome(s) to add the spawn costs to
@@ -422,7 +392,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
             )
         )
     );
-})
+});
 ```
 
   </TabItem>
@@ -431,7 +401,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 ### Remove Spawn Costs
 
-Allows for removing a Spawn Cost from a biome. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are removed from and the `EntityType` id or tag of the mobs to remove the spawn cost for.
+Allows for removing a spawn cost from a biome. Spawn costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. The modifier takes in the biome id or tag of the biomes the spawn costs are removed from, and the `EntityType` id or tag of the entities to remove the spawn cost for.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
@@ -454,34 +424,30 @@ Allows for removing a Spawn Cost from a biome. Spawn Costs are a newer way of ma
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for Datapack registry objects
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> REMOVE_SPAWN_COSTS_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_spawn_costs_example") // The registry name
+);
 
-public static final ResourceKey<BiomeModifier> REMOVE_SPAWN_COSTS_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_spawn_costs_example") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
     HolderGetter<EntityType<?>> entities = bootstrap.lookup(Registries.ENTITY_TYPE);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(REMOVE_SPAWN_COSTS_EXAMPLE,
         new RemoveSpawnCostsBiomeModifier(
-            // The biome(s) to remove the spawnc costs from
+            // The biome(s) to remove the spawn costs from
             biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
             // The entities to remove spawn costs for
             entities.getOrThrow(EntityTypeTags.SKELETONS)
         )
     );
-})
+});
 ```
 
   </TabItem>
@@ -490,25 +456,25 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 ### Add Legacy Carvers
 
-This Biome Modifier type allows adding Carver Caves and Ravines to biomes. (Think of what caves looked like pre-Caves and Cliffs update) This CANNOT add Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically Ravines and Carver Caves.
+This biome modifier type allows adding carver caves and ravines to biomes. These are what was used for cave generation before the Caves and Cliffs update. It CANNOT add noise caves to biomes, because noise caves are baked into the dimension's noise settings system and not actually tied to biomes.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
 
 ```json5
 {
-    "type": "neoforge:add_carvers",
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "minecraft:plains",
-    // Can either be an id "examplemod:add_carvers_example"
-    // List of ids ["examplemod:add_carvers_example", "minecraft:canyon", ...]
-    // Or a tag "#examplemod:configured_carver_tag"
-    "carvers": "examplemod:add_carvers_example",
-    // See GenerationStep.Carving in code for a list of valid enum names.
-    // Only `air` and `liquid` are available.
-    "step": "air"
+  "type": "neoforge:add_carvers",
+  // Can either be a biome id, such as "minecraft:plains",
+  // or a list of biome ids, such as ["minecraft:plains", "minecraft:badlands", ...],
+  // or a biome tag, such as "#c:is_overworld".
+  "biomes": "minecraft:plains",
+  // Can either be a carver id, such as "examplemod:add_carvers_example",
+  // or a list of carver ids, such as ["examplemod:add_carvers_example", "minecraft:canyon", ...],
+  // or a carver tag, such as "#examplemod:configured_carver_tag".
+  "carvers": "examplemod:add_carvers_example",
+  // See GenerationStep.Carving in code for a list of valid enum names.
+  // Only "air" and "liquid" are available.
+  "step": "air"
 }
 ```
 
@@ -516,27 +482,22 @@ This Biome Modifier type allows adding Carver Caves and Ravines to biomes. (Thin
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Assume we have some ConfiguredWorldCarver EXAMPLE_CARVER
+// Assume we have some ConfiguredWorldCarver named EXAMPLE_CARVER.
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> ADD_CARVERS_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_carvers_example") // The registry name
+);
 
-// Define keys for Datapack registry objects
-
-public static final ResourceKey<BiomeModifier> ADD_CARVERS_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_carvers_example") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
     HolderGetter<ConfiguredWorldCarver<?>> carvers = bootstrap.lookup(Registries.CONFIGURED_CARVER);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(ADD_CARVERS_EXAMPLE,
         new AddCarversBiomeModifier(
             // The biome(s) to generate within
@@ -547,7 +508,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
             GenerationStep.Carving.AIR
         )
     );
-})
+});
 ```
 
   </TabItem>
@@ -555,29 +516,30 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 ### Removing Legacy Carvers
 
-This Biome Modifier type allows removing Carver Caves and Ravines from biomes. (Think of what caves looked like pre-Caves and Cliffs update) This CANNOT remove Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically Ravines and Carver Caves.
+This biome modifier type allows removing carver caves and ravines from biomes. These are what was used for cave generation before the Caves and Cliffs update. It CANNOT remove noise caves from biomes, because noise caves are baked into the dimension's noise settings system and not actually tied to biomes.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
 
 ```json5
 {
-    "type": "neoforge:remove_carvers",
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#c:is_overworld",
-    // Can either be an id "minecraft:cave"
-    // List of ids ["minecraft:cave", "minecraft:canyon", ...]
-    // Or a tag "#examplemod:configured_carver_tag"
-    "carvers": "minecraft:cave",
-    // Can either be a single step "air"
-    // Or a list ["air", "liquid"]
-    // See GenerationStep.Carving for a list of valid enum names.
-    "steps": [
-        "air",
-        "liquid"
-    ]
+  "type": "neoforge:remove_carvers",
+  // Can either be a biome id, such as "minecraft:plains",
+  // or a list of biome ids, such as ["minecraft:plains", "minecraft:badlands", ...],
+  // or a biome tag, such as "#c:is_overworld".
+  "biomes": "minecraft:plains",
+  // Can either be a carver id, such as "examplemod:add_carvers_example",
+  // or a list of carver ids, such as ["examplemod:add_carvers_example", "minecraft:canyon", ...],
+  // or a carver tag, such as "#examplemod:configured_carver_tag".
+  "carvers": "examplemod:add_carvers_example",
+  // Can either be a single generation step, such as "air",
+  // or a list of generation steps, such as ["air", "liquid"].
+  // See GenerationStep.Carving for a list of valid enum names.
+  // Only "air" and "liquid" are available.
+  "steps": [
+    "air",
+    "liquid"
+  ]
 }
 ```
 
@@ -585,25 +547,21 @@ This Biome Modifier type allows removing Carver Caves and Ravines from biomes. (
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for Datapack registry objects
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> REMOVE_CARVERS_EXAMPLE = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_carvers_example") // The registry name
+);
 
-public static final ResourceKey<BiomeModifier> REMOVE_CARVERS_EXAMPLE =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_carvers_example") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
     HolderGetter<ConfiguredWorldCarver<?>> carvers = bootstrap.lookup(Registries.CONFIGURED_CARVER);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(REMOVE_CARVERS_EXAMPLE,
         new AddFeaturesBiomeModifier(
             // The biome(s) to remove from
@@ -617,15 +575,15 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
             )
         )
     );
-})
+});
 ```
 
   </TabItem>
 </Tabs>
 
-### The available values for the Decoration steps
+### Available Values for Decoration Steps
 
-The `step` field in many of these JSONs are referring to GenerationStep.Decoration enum. This enum has the steps listed out in this order which is the same order that the game uses for generating during worldgen. Try to put features in the stage that makes the most sense for them.
+The `step` or `steps` fields in many of the aforementioned JSONs are referring to the `GenerationStep.Decoration` enum. This enum has the steps listed out in the following order, which is the same order that the game uses for generating during worldgen. Try to put features in the step that makes the most sense for them.
 
 |           Step           | Description                                                                             |
 |:------------------------:|:----------------------------------------------------------------------------------------|
@@ -637,12 +595,12 @@ The `step` field in many of these JSONs are referring to GenerationStep.Decorati
 |      `strongholds`       | Dedicated for Stronghold structures. No feature is added here in unmodified Minecraft.  |
 |    `underground_ores`    | The step for all Ores and Veins to be added to. This includes Gold, Dirt, Granite, etc. |
 | `underground_decoration` | Used typically for decorating caves. Dripstone Cluster and Sculk Vein are here.         |
-|     `fluid_springs`      | The small Lavafalls and Waterfalls comes from features in this stage.                   |
+|     `fluid_springs`      | The small Lavafalls and Waterfalls come from features in this stage.                    |
 |   `vegetal_decoration`   | Nearly all plants (flowers, trees, vines, and more) are added to this stage.            |
 | `top_layer_modification` | Last to run. Used for placing Snow and Ice on the surface of cold biomes.               |
 
 
-## Creating Custom Biome Modifiers:
+## Creating Custom Biome Modifiers
 
 ### The `BiomeModifier` Implementation
 
@@ -652,7 +610,7 @@ Under the hood, Biome Modifiers are made up of three parts:
 - The [statically registered][staticreg] `MapCodec` that encodes and decodes the modifiers.
 - The JSON that constructs the `BiomeModifier`, using the registered id of the `MapCodec` as the indexable type.
 
-A `BiomeModifier` contains two methods: `#modify` and `#codec`. `modify` takes in the current `Biome` being constructor, the modifier `BiomeModifier.Phase`, and the builder of the biome to modify. Every `BiomeModifier` is called once per `Phase` to organize when certain modifications to the biome should occur:
+A `BiomeModifier` contains two methods: `#modify` and `#codec`. `modify` takes in a `Holder` of the current `Biome`, the current `BiomeModifier.Phase`, and the builder of the biome to modify. Every `BiomeModifier` is called once per `Phase` to organize when certain modifications to the biome should occur:
 
 | Phase               | Description                                                              |
 |:-------------------:|:-------------------------------------------------------------------------|
@@ -662,7 +620,7 @@ A `BiomeModifier` contains two methods: `#modify` and `#codec`. `modify` takes i
 | `MODIFY`            | Modifying single values (e.g., climate, colors).                         |
 | `AFTER_EVERYTHING`  | A catch-all for everything that needs to run after the standard phases.  |
 
-All Biome Modifiers contain a `type` key that references the id of the `MapCodec` used for the Biome Modifier. The `codec` takes in the `MapCodec` that encodes and decodes the modifiers. This `MapCodec` is [statically registered][staticreg], with its id used as the type of the Biome Modifier.
+All `BiomeModifier`s contain a `type` key that references the id of the `MapCodec` used for the `BiomeModifier`. The `codec` takes in the `MapCodec` that encodes and decodes the modifiers. This `MapCodec` is [statically registered][staticreg], with its id used as the `type` of the `BiomeModifier`.
 
 ```java
 public record ExampleBiomeModifier(HolderSet<Biome> biomes, int value) implements BiomeModifier {
@@ -681,11 +639,11 @@ public record ExampleBiomeModifier(HolderSet<Biome> biomes, int value) implement
 }
 
 // In some registration class
-private static final DeferredRegister<MapCodec<? extends BiomeModifier>> REGISTRAR =
+private static final DeferredRegister<MapCodec<? extends BiomeModifier>> BIOME_MODIFIERS =
     DeferredRegister.create(NeoForgeRegistries.Keys.BIOME_MODIFIER_SERIALIZERS, MOD_ID);
 
 public static final Holder<MapCodec<? extends BiomeModifier>> EXAMPLE_BIOME_MODIFIER =
-    REGISTRAR.register("example_biome_modifier", () -> RecordCodecBuilder.mapCodec(instance ->
+    BIOME_MODIFIERS.register("example_biome_modifier", () -> RecordCodecBuilder.mapCodec(instance ->
         instance.group(
             Biome.LIST_CODEC.fieldOf("biomes").forGetter(ExampleBiomeModifier::biomes),
             Codec.INT.fieldOf("value").forGetter(ExampleBiomeModifier::value)
@@ -694,37 +652,37 @@ public static final Holder<MapCodec<? extends BiomeModifier>> EXAMPLE_BIOME_MODI
 ```
 
 
-## Datagenning Biome Modifiers:
+## Datagenning Biome Modifiers
 
-A `BiomeModifier` JSON can be created with [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. The JSON will be placed at `data/<modid>/neoforge/biome_modifier/<path>.json`.
+A `BiomeModifier` JSON can be created through [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. The JSON will be placed at `data/<modid>/neoforge/biome_modifier/<path>.json`.
+
+For more information on how `RegistrySetBuilder` and `DatapackBuiltinEntriesProvider` work, please see the article on [Data Generation for Datapack Registries][datapackdatagen].
 
 ```java
-// Define keys for Datapack registry objects
+// Define the ResourceKey for our BiomeModifier.
+public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER = ResourceKey.create(
+    NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+    ResourceLocation.fromNamespaceAndPath(MOD_ID, "example_modifier") // The registry name
+);
 
-public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "example_modifier") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
+// BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
+    // Lookup any necessary registries.
+    // Static registries only need to be looked up if you need to grab the tag data.
     HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
 
-    // Register the Biome Modifiers
-
+    // Register the biome modifiers.
     bootstrap.register(EXAMPLE_MODIFIER,
         new ExampleBiomeModifier(
             biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
             20
         )
     );
-})
+});
 ```
+
+This will then result in the following JSON being created:
 
 ```json5
 // In data/examplemod/neoforge/biome_modifier/example_modifier.json
@@ -740,3 +698,4 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 [datareg]: ../concepts/registries.md#datapack-registries
 [staticreg]: ../concepts/registries.md#methods-for-registering
 [datagen]: ../resources/index.md#data-generation
+[datapackdatagen]: ../concepts/registries#data-generation-for-datapack-registries

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -121,6 +121,9 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 This Biome Modifier type removes features (such as trees or ores) from biomes so that they will no longer spawn during world generation. The modifier takes in the `Biome` id or tag of the biomes the features are removed from, a `PlacedFeature` id or tag of the features to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)s that the features will be removed from.
 
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+
 ```json5
 {
     "type": "neoforge:remove_features",
@@ -142,226 +145,8 @@ This Biome Modifier type removes features (such as trees or ores) from biomes so
 }
 ```
 
-### Add Spawns 
-
-This Biome Modifier type adds mob spawns to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are added to and the `SpawnerData` of the mobs to add. Each `SpawnerData` contains the mob id, the spawn weight, and the minimum/maximum number of mobs to spawn at a given time.
-
-**NOTE:** If you are a modder adding a new mob, make sure the mob has a spawn restriction registered to RegisterSpawnPlacementsEvent event.
-
-```json5
-{
-    "type": "neoforge:add_spawns",
-
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#namespace:biome_tag", 
-  
-    // Can be either a single object or a list of objects
-    "spawners": [
-      {
-        "type": "namespace:entity_type", // Type of mob to spawn
-        "weight": 100, // int, spawn weighting
-        "minCount": 1, // int, minimum pack size
-        "maxCount": 4 // int, maximum pack size
-      },
-      {
-        "type": "minecraft:ghast",
-        "weight": 1,
-        "minCount": 5,
-        "maxCount": 10
-      }
-    ]
-}
-```
-
-### Remove Spawns
-
-This Biome Modifier type removes mob spawns from biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are removed from and the `EntityType` id or tag of the mobs to remove.
-
-```json5
-{
-    "type": "neoforge:remove_spawns",
-
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#namespace:biome_tag",
-
-    // Can either be an id "minecraft:ghast"
-    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
-    // Or a tag "#minecraft:skeletons"
-    "entity_types": "#namespace:entitytype_tag"
-}
-```
-
-### Add Spawn Costs
-
-Allows for adding new Spawn Costs to biomes. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. It works by having the entities give off a `charge` that surrounds them and adds up with other entity's `charge`. Then when spawning, it looks for a spot where the total `charge` field at the location multiplied by the spawning entity's `charge` value is less than the spawning entity's `energy_budget`. This is an advanced way of spawning mobs so it is a good idea to reference the Soul Sand Valley Biome for existing values to borrow.
-
-The modifier takes in the `Biome` id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the mobs to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the mob. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based upon the charge provided for each entity spawned.
-
-**NOTE:** If you are a modder adding a new mob, make sure the mob has a spawn restriction registered to RegisterSpawnPlacementsEvent event.
-
-```json5
-{
-    "type": "neoforge:add_spawn_costs",
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#c:is_overworld",
-    // Can either be an id "minecraft:ghast"
-    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
-    // Or a tag "#minecraft:skeletons"
-    "entity_types": "#minecraft:skeletons",
-    "spawn_cost": {
-        // The energy budget
-        "energy_budget": 1.0,
-        // The amount of charge each entity takes up from the budget
-        "charge": 0.1
-    }
-}
-```
-
-### Remove Spawn Costs
-
-Allows for removing a Spawn Cost from a biome. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are removed from and the `EntityType` id or tag of the mobs to remove the spawn cost for.
-
-```json5
-{
-    "type": "neoforge:remove_spawn_costs",
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#c:is_overworld",
-    // Can either be an id "minecraft:ghast"
-    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
-    // Or a tag "#minecraft:skeletons"
-    "entity_types": "#minecraft:skeletons"
-}
-```
-
-### Add Legacy Carvers
-
-This Biome Modifier type allows adding Carver Caves and Ravines to biomes. (Think of what caves looked like pre-Caves and Cliffs update) This CANNOT add Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically Ravines and Carver Caves.
-
-```json5
-{
-    "type": "neoforge:add_carvers",
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "minecraft:plains",
-    // Can either be an id "examplemod:add_carvers_example"
-    // List of ids ["examplemod:add_carvers_example", "minecraft:canyon", ...]
-    // Or a tag "#examplemod:configured_carver_tag"
-    "carvers": "examplemod:add_carvers_example",
-    // See GenerationStep.Carving in code for a list of valid enum names.
-    // Only `air` and `liquid` are available.
-    "step": "air"
-}
-```
-
-### Removing Legacy Carvers
-
-This Biome Modifier type allows removing Carver Caves and Ravines from biomes. (Think of what caves looked like pre-Caves and Cliffs update) This CANNOT remove Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically Ravines and Carver Caves.
-
-```json5
-{
-    "type": "neoforge:remove_carvers",
-    // Can either be an id "minecraft:plains"
-    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
-    // Or a tag "#c:is_overworld"
-    "biomes": "#c:is_overworld",
-    // Can either be an id "minecraft:cave"
-    // List of ids ["minecraft:cave", "minecraft:canyon", ...]
-    // Or a tag "#examplemod:configured_carver_tag"
-    "carvers": "minecraft:cave",
-    // Can either be a single step "air"
-    // Or a list ["air", "liquid"]
-    // See GenerationStep.Carving for a list of valid enum names.
-    "steps": [
-        "air",
-        "liquid"
-    ]
-}
-```
-
-### The available values for the Decoration steps
-
-The `step` field in many of these JSONs are referring to GenerationStep.Decoration enum. This enum has the steps listed out in this order which is the same order that the game uses for generating during worldgen. Try to put features in the stage that makes the most sense for them.
-
-|           Step           | Description                                                                             |
-|:------------------------:|:----------------------------------------------------------------------------------------|
-|     `raw_generation`     | First to run. This is used for special terrain-like features such as Small End Islands. |
-|         `lakes`          | Dedicated to spawning pond-like feature such as Lava Lakes.                             |
-|  `local_modifications`   | For modifications to terrain such as Geodes, Icebergs, Boulders, or Dripstone.          |
-| `underground_structures` | Used for small underground structure-like features such as Dungeons or Fossils.         |
-|   `surface_structures`   | For small surface only structure-like features such as Desert Wells.                    |
-|      `strongholds`       | Dedicated for Stronghold structures. No feature is added here in unmodified Minecraft.  |
-|    `underground_ores`    | The step for all Ores and Veins to be added to. This includes Gold, Dirt, Granite, etc. |
-| `underground_decoration` | Used typically for decorating caves. Dripstone Cluster and Sculk Vein are here.         |
-|     `fluid_springs`      | The small Lavafalls and Waterfalls comes from features in this stage.                   |
-|   `vegetal_decoration`   | Nearly all plants (flowers, trees, vines, and more) are added to this stage.            |
-| `top_layer_modification` | Last to run. Used for placing Snow and Ice on the surface of cold biomes.               |
-
-
-## Datagenning Biome Modifiers:
-
-A `BiomeModifier` can be with [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. Biome Modifiers are located within `data/<modid>/neoforge/biome_modifier/<path>.json` All Biome Modifiers contain a `type` key that references the id of the `MapCodec` used for the Biome Modifier. All other settings provided by the Biome Modifier are added as additional keys on the root object.
-
-Biome Modifiers are made up of three parts:
-
-- The [datapack registered][datareg] `BiomeModifier` used to modify the biome builder.
-- The [statically registered][staticreg] `MapCodec` that encodes and decodes the modifiers.
-- The JSON that constructs the `BiomeModifier`, using the registered id of the `MapCodec` as the indexable type.
-
-```java
-// Define keys for datapack registry objects
-
-public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "example_modifier") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
-BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
-    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
-
-    // Register the Biome Modifiers
-
-    bootstrap.register(EXAMPLE_MODIFIER,
-        new ExampleBiomeModifier(
-            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
-            20
-        )
-    );
-})
-```
-
-```json5
-// In data/examplemod/neoforge/biome_modifier/example_modifier.json
-{
-    // The registy key of the MapCodec for the modifier
-    "type": "examplemod:example_biome_modifier",
-    // All additional settings are applied to the root object
-    "biomes": "#c:is_overworld",
-    "value": 20
-}
-```
-
-### Datagenning Existing Biome Modifiers
-
-NeoForge provides some basic Biome Modifiers for common usecases. The datagen implementation will be shown. All Biome Modifiers can be found in `BiomeModifiers`.
-
-### `RemoveFeaturesBiomeModifier`
-
-`RemoveFeaturesBiomeModifier` removes features from biomes. The modifier takes in the `Biome` id or tag of the biomes the features are removed from, a `PlacedFeature` id or tag of the features to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)`s that the features will be removed from.
+  </TabItem>
+  <TabItem value="datagen" label="Datagen">
 
 ```java
 // Define keys for datapack registry objects
@@ -399,11 +184,48 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 })
 ```
 
-### `AddSpawnsBiomeModifier`
+  </TabItem>
+</Tabs>
 
-`AddSpawnsBiomeModifier` adds mob spawning information to be used by `NaturalSpawner` to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are added to and the `SpawnerData` of the mobs to add. Each `SpawnerData` contains the mob id, the spawn weight, and the minimum/maximum number of mobs to spawn at a given time.
+
+### Add Spawns 
+
+This Biome Modifier type adds mob spawns to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are added to and the `SpawnerData` of the mobs to add. Each `SpawnerData` contains the mob id, the spawn weight, and the minimum/maximum number of mobs to spawn at a given time.
 
 **NOTE:** If you are a modder adding a new mob, make sure the mob has a spawn restriction registered to RegisterSpawnPlacementsEvent event.
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+
+```json5
+{
+    "type": "neoforge:add_spawns",
+
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#namespace:biome_tag", 
+  
+    // Can be either a single object or a list of objects
+    "spawners": [
+      {
+        "type": "namespace:entity_type", // Type of mob to spawn
+        "weight": 100, // int, spawn weighting
+        "minCount": 1, // int, minimum pack size
+        "maxCount": 4 // int, maximum pack size
+      },
+      {
+        "type": "minecraft:ghast",
+        "weight": 1,
+        "minCount": 5,
+        "maxCount": 10
+      }
+    ]
+}
+```
+
+  </TabItem>
+  <TabItem value="datagen" label="Datagen">
 
 ```java
 // Assume we have some EntityType EXAMPLE_ENTITY
@@ -440,9 +262,35 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 })
 ```
 
-### `RemoveSpawnsBiomeModifier`
+  </TabItem>
+</Tabs>
 
-`RemoveSpawnsBiomeModifier` removes mob spawning information from biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are removed from and the `EntityType` id or tag of the mobs to remove.
+
+### Remove Spawns
+
+This Biome Modifier type removes mob spawns from biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are removed from and the `EntityType` id or tag of the mobs to remove.
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+
+```json5
+{
+    "type": "neoforge:remove_spawns",
+
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#namespace:biome_tag",
+
+    // Can either be an id "minecraft:ghast"
+    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
+    // Or a tag "#minecraft:skeletons"
+    "entity_types": "#namespace:entitytype_tag"
+}
+```
+
+  </TabItem>
+  <TabItem value="datagen" label="Datagen">
 
 ```java
 // Define keys for datapack registry objects
@@ -475,11 +323,43 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 })
 ```
 
-### `AddSpawnCostsBiomeModifier`
+  </TabItem>
+</Tabs>
 
-`AddSpawnCostsBiomeModifier` adds spawn costs for mobs to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the mobs to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the mob. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based upon the charge provided for each entity spawned.
+
+### Add Spawn Costs
+
+Allows for adding new Spawn Costs to biomes. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. It works by having the entities give off a `charge` that surrounds them and adds up with other entity's `charge`. Then when spawning, it looks for a spot where the total `charge` field at the location multiplied by the spawning entity's `charge` value is less than the spawning entity's `energy_budget`. This is an advanced way of spawning mobs so it is a good idea to reference the Soul Sand Valley Biome for existing values to borrow.
+
+The modifier takes in the `Biome` id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the mobs to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the mob. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based upon the charge provided for each entity spawned.
 
 **NOTE:** If you are a modder adding a new mob, make sure the mob has a spawn restriction registered to RegisterSpawnPlacementsEvent event.
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+
+```json5
+{
+    "type": "neoforge:add_spawn_costs",
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#c:is_overworld",
+    // Can either be an id "minecraft:ghast"
+    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
+    // Or a tag "#minecraft:skeletons"
+    "entity_types": "#minecraft:skeletons",
+    "spawn_cost": {
+        // The energy budget
+        "energy_budget": 1.0,
+        // The amount of charge each entity takes up from the budget
+        "charge": 0.1
+    }
+}
+```
+
+  </TabItem>
+  <TabItem value="datagen" label="Datagen">
 
 ```java
 // Define keys for datapack registry objects
@@ -516,9 +396,33 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 })
 ```
 
-### `RemoveSpawnCostsBiomeModifier`
+  </TabItem>
+</Tabs>
 
-`RemoveSpawnsBiomeModifier` removes spawn costs for mobs from biomes. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are removed from and the `EntityType` id or tag of the mobs to remove the spawn cost for.
+
+### Remove Spawn Costs
+
+Allows for removing a Spawn Cost from a biome. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are removed from and the `EntityType` id or tag of the mobs to remove the spawn cost for.
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+
+```json5
+{
+    "type": "neoforge:remove_spawn_costs",
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#c:is_overworld",
+    // Can either be an id "minecraft:ghast"
+    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
+    // Or a tag "#minecraft:skeletons"
+    "entity_types": "#minecraft:skeletons"
+}
+```
+
+  </TabItem>
+  <TabItem value="datagen" label="Datagen">
 
 ```java
 // Define keys for datapack registry objects
@@ -551,9 +455,36 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 })
 ```
 
-### `AddCarversBiomeModifier`
+  </TabItem>
+</Tabs>
 
-`AddCarversBiomeModifier` adds carvers, such as caves, to biomes. The modifier takes in the `Biome` id or tag of the biomes the carvers are added to, a `ConfiguredWorldCarver` id or tag of the carvers to add to the selected biomes, and the `GenerationStep.Carving` the carvers will be generated within.
+
+### Add Legacy Carvers
+
+This Biome Modifier type allows adding Carver Caves and Ravines to biomes. (Think of what caves looked like pre-Caves and Cliffs update) This CANNOT add Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically Ravines and Carver Caves.
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+
+```json5
+{
+    "type": "neoforge:add_carvers",
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "minecraft:plains",
+    // Can either be an id "examplemod:add_carvers_example"
+    // List of ids ["examplemod:add_carvers_example", "minecraft:canyon", ...]
+    // Or a tag "#examplemod:configured_carver_tag"
+    "carvers": "examplemod:add_carvers_example",
+    // See GenerationStep.Carving in code for a list of valid enum names.
+    // Only `air` and `liquid` are available.
+    "step": "air"
+}
+```
+
+  </TabItem>
+  <TabItem value="datagen" label="Datagen">
 
 ```java
 // Assume we have some ConfiguredWorldCarver EXAMPLE_CARVER
@@ -590,9 +521,39 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 })
 ```
 
-### `RemoveCarversBiomeModifier`
+  </TabItem>
+</Tabs>
 
-`RemoveCarversBiomeModifier` removes carvers from biomes. The modifier takes in the `Biome` id or tag of the biomes the carvers are removed from, a `ConfiguredWorldCarver` id or tag of the carvers to remove from the selected biomes, and the `GenerationStep.Carving`s that the carvers will be removed from.
+### Removing Legacy Carvers
+
+This Biome Modifier type allows removing Carver Caves and Ravines from biomes. (Think of what caves looked like pre-Caves and Cliffs update) This CANNOT remove Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically Ravines and Carver Caves.
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
+
+```json5
+{
+    "type": "neoforge:remove_carvers",
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#c:is_overworld",
+    // Can either be an id "minecraft:cave"
+    // List of ids ["minecraft:cave", "minecraft:canyon", ...]
+    // Or a tag "#examplemod:configured_carver_tag"
+    "carvers": "minecraft:cave",
+    // Can either be a single step "air"
+    // Or a list ["air", "liquid"]
+    // See GenerationStep.Carving for a list of valid enum names.
+    "steps": [
+        "air",
+        "liquid"
+    ]
+}
+```
+
+  </TabItem>
+  <TabItem value="datagen" label="Datagen">
 
 ```java
 // Define keys for datapack registry objects
@@ -630,9 +591,80 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 })
 ```
 
+  </TabItem>
+</Tabs>
+
+### The available values for the Decoration steps
+
+The `step` field in many of these JSONs are referring to GenerationStep.Decoration enum. This enum has the steps listed out in this order which is the same order that the game uses for generating during worldgen. Try to put features in the stage that makes the most sense for them.
+
+|           Step           | Description                                                                             |
+|:------------------------:|:----------------------------------------------------------------------------------------|
+|     `raw_generation`     | First to run. This is used for special terrain-like features such as Small End Islands. |
+|         `lakes`          | Dedicated to spawning pond-like feature such as Lava Lakes.                             |
+|  `local_modifications`   | For modifications to terrain such as Geodes, Icebergs, Boulders, or Dripstone.          |
+| `underground_structures` | Used for small underground structure-like features such as Dungeons or Fossils.         |
+|   `surface_structures`   | For small surface only structure-like features such as Desert Wells.                    |
+|      `strongholds`       | Dedicated for Stronghold structures. No feature is added here in unmodified Minecraft.  |
+|    `underground_ores`    | The step for all Ores and Veins to be added to. This includes Gold, Dirt, Granite, etc. |
+| `underground_decoration` | Used typically for decorating caves. Dripstone Cluster and Sculk Vein are here.         |
+|     `fluid_springs`      | The small Lavafalls and Waterfalls comes from features in this stage.                   |
+|   `vegetal_decoration`   | Nearly all plants (flowers, trees, vines, and more) are added to this stage.            |
+| `top_layer_modification` | Last to run. Used for placing Snow and Ice on the surface of cold biomes.               |
+
+
+## Datagenning Biome Modifiers:
+
+A `BiomeModifier` JSON can be created with [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. The JSON will be placed at `data/<modid>/neoforge/biome_modifier/<path>.json`.
+
+```java
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "example_modifier") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(EXAMPLE_MODIFIER,
+        new ExampleBiomeModifier(
+            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
+            20
+        )
+    );
+})
+```
+
+```json5
+// In data/examplemod/neoforge/biome_modifier/example_modifier.json
+{
+    // The registy key of the MapCodec for the modifier
+    "type": "examplemod:example_biome_modifier",
+    // All additional settings are applied to the root object
+    "biomes": "#c:is_overworld",
+    "value": 20
+}
+```
+
 ## Creating Custom Biome Modifiers:
 
 ### The `BiomeModifier` Implementation
+
+Under the hood, Biome Modifiers are made up of three parts:
+
+- The [datapack registered][datareg] `BiomeModifier` used to modify the biome builder.
+- The [statically registered][staticreg] `MapCodec` that encodes and decodes the modifiers.
+- The JSON that constructs the `BiomeModifier`, using the registered id of the `MapCodec` as the indexable type.
 
 A `BiomeModifier` contains two methods: `#modify` and `#codec`. `modify` takes in the current `Biome` being constructor, the modifier `BiomeModifier.Phase`, and the builder of the biome to modify. Every `BiomeModifier` is called once per `Phase` to organize when certain modifications to the biome should occur:
 
@@ -644,7 +676,7 @@ A `BiomeModifier` contains two methods: `#modify` and `#codec`. `modify` takes i
 | `MODIFY`            | Modifying single values (e.g., climate, colors).                         |
 | `AFTER_EVERYTHING`  | A catch-all for everything that needs to run after the standard phases.  |
 
-`codec` takes in the `MapCodec` that encodes and decodes the modifiers. This `MapCodec` is [statically registered][staticreg], with its id used as the type of the Biome Modifier.
+All Biome Modifiers contain a `type` key that references the id of the `MapCodec` used for the Biome Modifier. The `codec` takes in the `MapCodec` that encodes and decodes the modifiers. This `MapCodec` is [statically registered][staticreg], with its id used as the type of the Biome Modifier.
 
 ```java
 public record ExampleBiomeModifier(HolderSet<Biome> biomes, int value) implements BiomeModifier {

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -8,25 +8,25 @@ Biome Modifiers are a data-driven system that allows for changing many aspects o
 ### Recommended Section To Read:
 
 - Players or Pack Makers:
-  - '[Applying Biome Modifiers](#Applying-Biome-Modifiers)'
-  - '[Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)'
+  - [Applying Biome Modifiers](#Applying-Biome-Modifiers)
+  - [Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)
 
 
 - Modders doing simple additions or removal biome modifications:
-  - '[Applying Biome Modifiers](#Applying-Biome-Modifiers)'
-  - '[Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)'
-  - '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)'
+  - [Applying Biome Modifiers](#Applying-Biome-Modifiers)
+  - [Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)
+  - [Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)
 
 
 - Modders who want to do custom or complex biome modifications:
-  - '[Applying Biome Modifiers](#Applying-Biome-Modifiers)'
-  - '[Creating Custom Biome Modifiers](#Creating-Custom-Biome-Modifiers)'
-  - '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)'
+  - [Applying Biome Modifiers](#Applying-Biome-Modifiers)
+  - [Creating Custom Biome Modifiers](#Creating-Custom-Biome-Modifiers)
+  - [Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)
 
 
 ## Applying Biome Modifiers:
 
-Biome Modifiers are like a set of modifications to apply to a biome when the game loads. To have NeoForge load a Biome Modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a Datapack. Then once NeoForge loads the Biome Modifier, it'll read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing Biome Modifiers from mods can be overridden by Datapacks having a new JSON file at the exact same location and name.
+To have NeoForge load a Biome Modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a Datapack. Then once NeoForge loads the Biome Modifier, it'll read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing Biome Modifiers from mods can be overridden by Datapacks having a new JSON file at the exact same location and name.
 
 The JSON file can be created by hand following the examples in the '[Built-in NeoForge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)' section or be datagenned as shown in the '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)' section.
 
@@ -221,7 +221,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 This Biome Modifier type adds mob spawns to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are added to and the `SpawnerData` of the mobs to add. Each `SpawnerData` contains the mob id, the spawn weight, and the minimum/maximum number of mobs to spawn at a given time.
 
-**NOTE:** If you are a modder adding a new mob, make sure the mob has a spawn restriction registered to RegisterSpawnPlacementsEvent event.
+**NOTE:** If you are a modder adding a new mob, make sure the mob has a spawn restriction registered to RegisterSpawnPlacementsEvent event. If you do not register a spawn restriction, your mob could spawn in mid-air, fall and die. Spawn restrictions are used to make mobs spawn on surfaces or in water safely.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
@@ -642,49 +642,6 @@ The `step` field in many of these JSONs are referring to GenerationStep.Decorati
 | `top_layer_modification` | Last to run. Used for placing Snow and Ice on the surface of cold biomes.               |
 
 
-## Datagenning Biome Modifiers:
-
-A `BiomeModifier` JSON can be created with [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. The JSON will be placed at `data/<modid>/neoforge/biome_modifier/<path>.json`.
-
-```java
-// Define keys for Datapack registry objects
-
-public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER =
-    ResourceKey.create(
-        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
-        ResourceLocation.fromNamespaceAndPath(MOD_ID, "example_modifier") // The registry name
-    );
-
-// For some RegistrySetBuilder BUILDER
-// being passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent
-BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
-    // Lookup any necessary registries
-    // Static registries only need to be looked up if you need to grab the tag data
-    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
-
-    // Register the Biome Modifiers
-
-    bootstrap.register(EXAMPLE_MODIFIER,
-        new ExampleBiomeModifier(
-            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
-            20
-        )
-    );
-})
-```
-
-```json5
-// In data/examplemod/neoforge/biome_modifier/example_modifier.json
-{
-    // The registy key of the MapCodec for the modifier
-    "type": "examplemod:example_biome_modifier",
-    // All additional settings are applied to the root object
-    "biomes": "#c:is_overworld",
-    "value": 20
-}
-```
-
 ## Creating Custom Biome Modifiers:
 
 ### The `BiomeModifier` Implementation
@@ -734,6 +691,50 @@ public static final Holder<MapCodec<? extends BiomeModifier>> EXAMPLE_BIOME_MODI
             Codec.INT.fieldOf("value").forGetter(ExampleBiomeModifier::value)
         ).apply(instance, ExampleBiomeModifier::new)
     ));
+```
+
+
+## Datagenning Biome Modifiers:
+
+A `BiomeModifier` JSON can be created with [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. The JSON will be placed at `data/<modid>/neoforge/biome_modifier/<path>.json`.
+
+```java
+// Define keys for Datapack registry objects
+
+public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "example_modifier") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(EXAMPLE_MODIFIER,
+        new ExampleBiomeModifier(
+            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
+            20
+        )
+    );
+})
+```
+
+```json5
+// In data/examplemod/neoforge/biome_modifier/example_modifier.json
+{
+    // The registy key of the MapCodec for the modifier
+    "type": "examplemod:example_biome_modifier",
+    // All additional settings are applied to the root object
+    "biomes": "#c:is_overworld",
+    "value": 20
+}
 ```
 
 [datareg]: ../concepts/registries.md#datapack-registries

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -1,0 +1,648 @@
+# Biome Modifiers
+
+Biome Modifiers are a data-driven system that allows for changing many aspects of a biome. Ranging from injecting or removing PlacedFeatures, adding or deleting mob spawns, changing the climate, and adjusting foliage and water color. NeoForge provides several default Biome Modifiers that covers the majority of use cases for both players and modders.
+
+For players, you will want to see the [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers) section and [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) section.
+
+For modders looking to do basic goals, you will want to see the [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers), [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) and possibly [#Datagenning-Biome-Modifiers](#Datagenning-Biome-Modifiers) sections for your mods.
+
+For modders looking to do advance custom Biome Modifiers, check out the [#Creating-Custom-Biome-Modifiers](#Creating-Custom-Biome-Modifiers) section.
+
+## Applying Biome Modifiers:
+
+To apply a Biome Modifier, the JSON file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a datapack. Neoforge will automatically detect and load the Biome Modifier and apply it to the game. Existing Biome Modifiers can be overridden by having a new JSON file at the exact same location and name.
+
+The JSON file can be created by hand following the examples in [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers) section or be datagenned as shown in [#Datagenning-Biome-Modifiers](#Datagenning-Biome-Modifiers) section.
+
+## Builtin Neoforge Biome Modifiers:
+
+### None
+
+A no-op Biome Modifier type, whose jsons have the following format:
+```json5
+{
+  "type": "neoforge:none"
+}
+```
+
+This allows pack devs or server operators to disable mods' Biome Modifiers by overriding their Biome Modifier jsons with the above.
+
+### Add Features
+
+This Biome Modifier type adds placed features to biomes. The modifier takes in the `Biome` id or tag of the biomes the features are added to, a `PlacedFeature` id or tag of the features to add to the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps) the features will be generated within.
+
+```json5
+{
+    "type": "neoforge:add_features",
+
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#namespace:your_biome_tag",
+
+    // Can either be an id "examplemod:add_features_example"
+    // List of ids ["examplemod:add_features_example", "minecraft:ice_spike", ...]
+    // Or a tag "#examplemod:placed_feature_tag"
+    "features": "namespace:your_feature",
+
+    // See GenerationStep.Decoration enum in code for a list of valid enum names.
+    // The Decoration step section further down also has the list of values for reference.
+    "step": "underground_ores"
+}
+```
+
+### Remove Features
+
+This Biome Modifier type removes features from biomes. The modifier takes in the `Biome` id or tag of the biomes the features are removed from, a PlacedFeature id or tag of the features to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)s that the features will be removed from.
+
+```json5
+{
+    "type": "neoforge:remove_features",
+
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#namespace:your_biome_tag",
+
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "features": "namespace:your_feature",
+  
+    // Optional field specifying a GenerationStep or list of GenerationSteps to remove features from, defaults to all if not specified.
+    // See GenerationStep.Decoration enum in code for a list of valid enum names.
+    // The Decoration step section further down also has the list of values for reference.
+    "steps": [ "underground_ores", "underground_ores" ] 
+}
+```
+
+### Add Spawns 
+
+This Biome Modifier type adds mob spawns to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are added to and the `SpawnerData` of the mobs to add. Each `SpawnerData` contains the mob id, the spawn weight, and the minimum/maximum number of mobs to spawn at a given time.
+
+```json5
+{
+    "type": "forge:add_spawns",
+
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#namespace:biome_tag", 
+  
+    // Can be either a single object or a list of objects
+    "spawners": [
+      {
+        "type": "namespace:entity_type", // Type of mob to spawn
+        "weight": 100, // int, spawn weighting
+        "minCount": 1, // int, minimum pack size
+        "maxCount": 4 // int, maximum pack size
+      },
+      {
+        "type": "minecraft:ghast",
+        "weight": 1,
+        "minCount": 5,
+        "maxCount": 10
+      }
+    ]
+}
+```
+
+### Remove Spawns
+
+This Biome Modifier type removes mob spawns from biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are removed from and the `EntityType` id or tag of the mobs to remove.
+
+```json5
+{
+    "type": "forge:remove_spawns",
+
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#namespace:biome_tag",
+
+    // Can either be an id "minecraft:ghast"
+    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
+    // Or a tag "#minecraft:skeletons"
+    "entity_types": "#namespace:entitytype_tag"
+}
+```
+
+### Add Spawn Costs
+
+Allows for adding new Spawn Costs to biomes. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the mobs to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the mob. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based upon the charge provided for each entity spawned.
+
+```json5
+{
+    "type": "neoforge:add_spawn_costs",
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#c:is_overworld",
+    // Can either be an id "minecraft:ghast"
+    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
+    // Or a tag "#minecraft:skeletons"
+    "entity_types": "#minecraft:skeletons",
+    "spawn_cost": {
+        // The energy budget
+        "energy_budget": 1.0,
+        // The amount of charge each entity takes up from the budget
+        "charge": 0.1
+    }
+}
+```
+
+### Remove Spawn Costs
+
+Allows for removing a Spawn Cost from a biome. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are removed from and the `EntityType` id or tag of the mobs to remove the spawn cost for.
+
+```json5
+{
+    "type": "neoforge:remove_spawn_costs",
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#c:is_overworld",
+    // Can either be an id "minecraft:ghast"
+    // List of ids ["minecraft:ghast", "minecraft:skeleton", ...]
+    // Or a tag "#minecraft:skeletons"
+    "entity_types": "#minecraft:skeletons"
+}
+```
+
+### Add Legacy Carvers
+
+This Biome Modifier type allows adding old caves and ravines to biomes. This CANNOT add Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically ravines and old caves.
+
+```json5
+{
+    "type": "neoforge:add_carvers",
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "minecraft:plains",
+    // Can either be an id "examplemod:add_carvers_example"
+    // List of ids ["examplemod:add_carvers_example", "minecraft:canyon", ...]
+    // Or a tag "#examplemod:configured_carver_tag"
+    "carvers": "examplemod:add_carvers_example",
+    // See GenerationStep.Carving in code for a list of valid enum names.
+    // Only `air` and `liquid` are available.
+    "step": "air"
+}
+```
+
+### Removing Legacy Carvers
+
+This Biome Modifier type allows removing old caves and ravines from biomes. This CANNOT remove Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically ravines and old caves.
+
+```json5
+{
+    "type": "neoforge:remove_carvers",
+    // Can either be an id "minecraft:plains"
+    // List of ids ["minecraft:plains", "minecraft:badlands", ...]
+    // Or a tag "#c:is_overworld"
+    "biomes": "#c:is_overworld",
+    // Can either be an id "minecraft:cave"
+    // List of ids ["minecraft:cave", "minecraft:canyon", ...]
+    // Or a tag "#examplemod:configured_carver_tag"
+    "carvers": "minecraft:cave",
+    // Can either be a single step "air"
+    // Or a list ["air", "liquid"]
+    // See GenerationStep.Carving for a list of valid enum names.
+    "steps": [
+        "air",
+        "liquid"
+    ]
+}
+```
+
+### Word of Warning
+
+- Avoid using Biome Modifiers to add vanilla placed features to biomes, as this may cause a feature cycle violation (the game will crash if two biomes have the same two features in their feature lists but in different orders within same GenerationStep). Placed features can be referenced in biome jsons or added via Biome Modifiers, but should not be used in both. Make a new copy of a vanilla Placed Feature is ideal for adding it safely to biomes.
+
+
+- Avoid adding the same placed feature with more than one Biome Modifier, as this can cause feature cycle violations.
+
+### The available values for the Decoration steps
+
+The `step` field in many of these JSONs are referring to GenerationStep.Decoration enum. This enum has the steps listed out in this order which is the same order that the game uses for generating during worldgen:
+
+    raw_generation
+    lakes
+    local_modifications
+    underground_structures
+    surface_structures
+    strongholds
+    underground_ores
+    underground_decoration
+    fluid_springs
+    vegetal_decoration
+    top_layer_modification
+
+
+## Datagenning Biome Modifiers:
+
+A `BiomeModifier` can be with [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. Biome Modifiers are located within `data/<modid>/neoforge/biome_modifier/<path>.json` All Biome Modifiers contain a `type` key that references the id of the `MapCodec` used for the Biome Modifier. All other settings provided by the Biome Modifier are added as additional keys on the root object.
+
+```java
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "example_modifier") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(EXAMPLE_MODIFIER,
+        new ExampleBiomeModifier(
+            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
+            20
+        )
+    );
+})
+```
+
+```json5
+// In data/examplemod/neoforge/biome_modifier/example_modifier.json
+{
+    // The registy key of the MapCodec for the modifier
+    "type": "examplemod:example_biome_modifier",
+    // All additional settings are applied to the root object
+    "biomes": "#c:is_overworld",
+    "value": 20
+}
+```
+
+### Datagenning Existing Biome Modifiers
+
+NeoForge provides some basic Biome Modifiers for common usecases. The datagen implementation will be shown. All Biome Modifiers can be found in `BiomeModifiers`.
+
+### `AddFeaturesBiomeModifier`
+
+`AddFeaturesBiomeModifier` adds features, such as ore generation, to biomes. The modifier takes in the `Biome` id or tag of the biomes the features are added to, a `PlacedFeature` id or tag of the features to add to the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps) the features will be generated within.
+
+```java
+// Assume we have some PlacedFeature EXAMPLE_PLACED_FEATURE
+
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> ADD_FEATURES_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_features_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+    HolderGetter<PlacedFeature> placedFeatures = bootstrap.lookup(Registries.PLACED_FEATURE);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(ADD_FEATURES_EXAMPLE,
+        new AddFeaturesBiomeModifier(
+            // The biome(s) to generate within
+            HolderSet.direct(biomes.getOrThrow(Biomes.PLAINS)),
+            // The feature(s) to generate within the biomes
+            HolderSet.direct(placedFeatures.getOrThrow(EXAMPLE_PLACED_FEATURE)),
+            // The generation step
+            GenerationStep.Decoration.LOCAL_MODIFICATIONS
+        )
+    );
+})
+```
+
+### `RemoveFeaturesBiomeModifier`
+
+`RemoveFeaturesBiomeModifier` removes features from biomes. The modifier takes in the `Biome` id or tag of the biomes the features are removed from, a `PlacedFeature` id or tag of the features to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)`s that the features will be removed from.
+
+```java
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> REMOVE_FEATURES_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_features_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+    HolderGetter<PlacedFeature> placedFeatures = bootstrap.lookup(Registries.PLACED_FEATURE);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(REMOVE_FEATURES_EXAMPLE,
+        new RemoveFeaturesBiomeModifier(
+            // The biome(s) to remove from
+            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
+            // The feature(s) to remove from the biomes
+            HolderSet.direct(placedFeatures.getOrThrow(OrePlacements.ORE_DIAMOND)),
+            // The generation steps to remove from
+            Set.of(
+                GenerationStep.Decoration.LOCAL_MODIFICATIONS,
+                GenerationStep.Decoration.UNDERGROUND_ORES
+            )
+        )
+    );
+})
+```
+
+### `AddSpawnsBiomeModifier`
+
+`AddSpawnsBiomeModifier` adds mob spawning information to be used by `NaturalSpawner` to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are added to and the `SpawnerData` of the mobs to add. Each `SpawnerData` contains the mob id, the spawn weight, and the minimum/maximum number of mobs to spawn at a given time.
+
+```java
+// Assume we have some EntityType EXAMPLE_ENTITY
+
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> ADD_SPAWNS_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_spawns_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(ADD_SPAWNS_EXAMPLE,
+        new AddSpawnsBiomeModifier(
+            // The biome(s) to spawn the mobs within
+            HolderSet.direct(biomes.getOrThrow(Biomes.PLAINS)),
+            // The spawners of the entities to add
+            List.of(
+                new SpawnerData(EXAMPLE_ENTITY, 100, 1, 4),
+                new SpawnerData(EntityType.GHAST, 1, 5, 10)
+            )
+        )
+    );
+})
+```
+
+### `RemoveSpawnsBiomeModifier`
+
+`RemoveSpawnsBiomeModifier` removes mob spawning information from biomes. The modifier takes in the `Biome` id or tag of the biomes the spawning information are removed from and the `EntityType` id or tag of the mobs to remove.
+
+```java
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> REMOVE_SPAWNS_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_spawns_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+    HolderGetter<EntityType<?>> entities = bootstrap.lookup(Registries.ENTITY_TYPE);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(REMOVE_SPAWNS_EXAMPLE,
+        new RemoveSpawnsBiomeModifier(
+            // The biome(s) to remove the spawns from
+            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
+            // The entities to remove spawns for
+            entities.getOrThrow(EntityTypeTags.SKELETONS)
+        )
+    );
+})
+```
+
+### `AddCarversBiomeModifier`
+
+`AddCarversBiomeModifier` adds carvers, such as caves, to biomes. The modifier takes in the `Biome` id or tag of the biomes the carvers are added to, a `ConfiguredWorldCarver` id or tag of the carvers to add to the selected biomes, and the `GenerationStep.Carving` the carvers will be generated within.
+
+```java
+// Assume we have some ConfiguredWorldCarver EXAMPLE_CARVER
+
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> ADD_CARVERS_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_carvers_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+    HolderGetter<ConfiguredWorldCarver<?>> carvers = bootstrap.lookup(Registries.CONFIGURED_CARVER);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(ADD_CARVERS_EXAMPLE,
+        new AddCarversBiomeModifier(
+            // The biome(s) to generate within
+            HolderSet.direct(biomes.getOrThrow(Biomes.PLAINS)),
+            // The carver(s) to generate within the biomes
+            HolderSet.direct(carvers.getOrThrow(EXAMPLE_CARVER)),
+            // The generation step
+            GenerationStep.Carving.AIR
+        )
+    );
+})
+```
+
+### `RemoveCarversBiomeModifier`
+
+`RemoveCarversBiomeModifier` removes carvers from biomes. The modifier takes in the `Biome` id or tag of the biomes the carvers are removed from, a `ConfiguredWorldCarver` id or tag of the carvers to remove from the selected biomes, and the `GenerationStep.Carving`s that the carvers will be removed from.
+
+```java
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> REMOVE_CARVERS_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_carvers_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+    HolderGetter<ConfiguredWorldCarver<?>> carvers = bootstrap.lookup(Registries.CONFIGURED_CARVER);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(REMOVE_CARVERS_EXAMPLE,
+        new AddFeaturesBiomeModifier(
+            // The biome(s) to remove from
+            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
+            // The carver(s) to remove from the biomes
+            HolderSet.direct(carvers.getOrThrow(Carvers.CAVE)),
+            // The generation steps to remove from
+            Set.of(
+                GenerationStep.Carving.AIR,
+                GenerationStep.Carving.LIQUID
+            )
+        )
+    );
+})
+```
+
+### `AddSpawnCostsBiomeModifier`
+
+`AddSpawnCostsBiomeModifier` adds spawn costs for mobs to biomes. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the mobs to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the mob. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based upon the charge provided for each entity spawned.
+
+```java
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> ADD_SPAWN_COSTS_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "add_spawn_costs_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+    HolderGetter<EntityType<?>> entities = bootstrap.lookup(Registries.ENTITY_TYPE);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(ADD_SPAWN_COSTS_EXAMPLE,
+        new AddSpawnCostsBiomeModifier(
+            // The biome(s) to add the spawn costs to
+            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
+            // The entities to add the spawn costs for
+            entities.getOrThrow(EntityTypeTags.SKELETONS),
+            new MobSpawnSettings.MobSpawnCost(
+                1.0, // The energy budget
+                0.1  // The amount of charge each entity takes up from the budget
+            )
+        )
+    );
+})
+```
+
+### `RemoveSpawnCostsBiomeModifier`
+
+`RemoveSpawnsBiomeModifier` removes spawn costs for mobs from biomes. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are removed from and the `EntityType` id or tag of the mobs to remove the spawn cost for.
+
+```java
+// Define keys for datapack registry objects
+
+public static final ResourceKey<BiomeModifier> REMOVE_SPAWN_COSTS_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "remove_spawn_costs_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+//   being passed to DatapackBuiltinEntriesProvider
+//   in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    // Lookup any necessary registries
+    // Static registries only need to be looked up if you need to grab the tag data
+    HolderGetter<Biome> biomes = bootstrap.lookup(Registries.BIOME);
+    HolderGetter<EntityType<?>> entities = bootstrap.lookup(Registries.ENTITY_TYPE);
+
+    // Register the Biome Modifiers
+
+    bootstrap.register(REMOVE_SPAWN_COSTS_EXAMPLE,
+        new RemoveSpawnCostsBiomeModifier(
+            // The biome(s) to remove the spawnc costs from
+            biomes.getOrThrow(Tags.Biomes.IS_OVERWORLD),
+            // The entities to remove spawn costs for
+            entities.getOrThrow(EntityTypeTags.SKELETONS)
+        )
+    );
+})
+```
+
+## Creating Custom Biome Modifiers:
+
+Biome Modifiers are made up of three parts:
+
+- The [datapack registered][datareg] `BiomeModifier` used to modify the biome builder.
+- The [statically registered][staticreg] `MapCodec` that encodes and decodes the modifiers.
+- The JSON that constructs the `BiomeModifier`, using the registered id of the `MapCodec` as the indexable type.
+
+### The `BiomeModifier` Implementation
+
+A `BiomeModifier` contains two methods: `#modify` and `#codec`. `modify` takes in the current `Biome` being constructor, the modifier `BiomeModifier.Phase`, and the builder of the biome to modify. Every `BiomeModifier` is called once per `Phase` to organize when certain modifications to the biome should occur:
+
+| Phase               | Description                                                              |
+|:-------------------:|:-------------------------------------------------------------------------|
+| `BEFORE_EVERYTHING` | A catch-all for everything that needs to run before the standard phases. |
+| `ADD`               | Adding features, mob spawns, etc.                                        |
+| `REMOVE`            | Removing features, mob spawns, etc.                                      |
+| `MODIFY`            | Modifying single values (e.g., climate, colors).                         |
+| `AFTER_EVERYTHING`  | A catch-all for everything that needs to run after the standard phases.  |
+
+`codec` takes in the `MapCodec` that encodes and decodes the modifiers. This `MapCodec` is [statically registered][staticreg], with its id used as the type of the Biome Modifier.
+
+```java
+public record ExampleBiomeModifier(HolderSet<Biome> biomes, int value) implements BiomeModifier {
+    
+    @Override
+    public void modify(Holder<Biome> biome, Phase phase, ModifiableBiomeInfo.BiomeInfo.Builder builder) {
+        if (phase == /* Pick the phase that best matches what your want to modify */) {
+            // Modify the 'builder', checking any information about the biome itself
+        }
+    }
+
+    @Override
+    public MapCodec<? extends BiomeModifier> codec() {
+        return EXAMPLE_BIOME_MODIFIER.value();
+    }
+}
+
+// In some registration class
+private static final DeferredRegister<MapCodec<? extends BiomeModifier>> REGISTRAR =
+    DeferredRegister.create(NeoForgeRegistries.Keys.BIOME_MODIFIER_SERIALIZERS, MOD_ID);
+
+public static final Holder<MapCodec<? extends BiomeModifier>> EXAMPLE_BIOME_MODIFIER =
+    REGISTRAR.register("example_biome_modifier", () -> RecordCodecBuilder.mapCodec(instance ->
+        instance.group(
+            Biome.LIST_CODEC.fieldOf("biomes").forGetter(ExampleBiomeModifier::biomes),
+            Codec.INT.fieldOf("value").forGetter(ExampleBiomeModifier::value)
+        ).apply(instance, ExampleBiomeModifier::new)
+    ));
+```
+
+[datareg]: ../concepts/registries.md#datapack-registries
+[staticreg]: ../concepts/registries.md#methods-for-registering
+[datagen]: ../resources/index.md#data-generation

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -26,7 +26,7 @@ Biome Modifiers are a data-driven system that allows for changing many aspects o
 
 ## Applying Biome Modifiers
 
-To have NeoForge load a Biome Modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a Datapack. Then once NeoForge loads the Biome Modifier, it'll read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing Biome Modifiers from mods can be overridden by Datapacks having a new JSON file at the exact same location and name.
+To have NeoForge load a biome modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources, or in a [Datapack][datapacks]. Then, once NeoForge loads the biome modifier, it will read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing biome modifiers from mods can be overridden by datapacks having a new JSON file at the exact same location and name.
 
 The JSON file can be created by hand following the examples in the '[Built-in NeoForge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)' section or be datagenned as shown in the '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)' section.
 
@@ -697,5 +697,6 @@ This will then result in the following JSON being created:
 
 [datareg]: ../concepts/registries.md#datapack-registries
 [staticreg]: ../concepts/registries.md#methods-for-registering
+[datapacks]: ../resources/index.md#data
 [datagen]: ../resources/index.md#data-generation
 [datapackdatagen]: ../concepts/registries#data-generation-for-datapack-registries

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -36,7 +36,7 @@ These Biome Modifiers are registered by NeoForge for anyone to use. The JSON exa
 
 ### None
 
-This Biome Modifier has no operation and will do no modification. Pack makers and players can use this in a Datapack to disable mods' Biome Modifiers by overriding their Biome Modifier jsons with the below. There is no Datagen code to make this modifier.
+This Biome Modifier has no operation and will do no modification. Pack makers and players can use this in a Datapack to disable mods' Biome Modifiers by overriding their Biome Modifier jsons with the below.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
@@ -45,6 +45,27 @@ This Biome Modifier has no operation and will do no modification. Pack makers an
 {
   "type": "neoforge:none"
 }
+```
+
+  </TabItem>
+  <TabItem value="datagen" label="Datagen">
+
+```java
+// Define keys for Datapack registry objects
+public static final ResourceKey<BiomeModifier> NO_OP_EXAMPLE =
+    ResourceKey.create(
+        NeoForgeRegistries.Keys.BIOME_MODIFIERS, // The registry this key is for
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "no_op_example") // The registry name
+    );
+
+// For some RegistrySetBuilder BUILDER
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
+BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
+    
+    // Register the Biome Modifiers
+    bootstrap.register(NO_OP_EXAMPLE, NoneBiomeModifier.INSTANCE);
+})
 ```
 
   </TabItem>
@@ -92,8 +113,8 @@ public static final ResourceKey<BiomeModifier> ADD_FEATURES_EXAMPLE =
     );
 
 // For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries
     // Static registries only need to be looked up if you need to grab the tag data
@@ -166,8 +187,8 @@ public static final ResourceKey<BiomeModifier> REMOVE_FEATURES_EXAMPLE =
     );
 
 // For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries
     // Static registries only need to be looked up if you need to grab the tag data
@@ -247,8 +268,8 @@ public static final ResourceKey<BiomeModifier> ADD_SPAWNS_EXAMPLE =
     );
 
 // For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries
     // Static registries only need to be looked up if you need to grab the tag data
@@ -310,8 +331,8 @@ public static final ResourceKey<BiomeModifier> REMOVE_SPAWNS_EXAMPLE =
     );
 
 // For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries
     // Static registries only need to be looked up if you need to grab the tag data
@@ -379,8 +400,8 @@ public static final ResourceKey<BiomeModifier> ADD_SPAWN_COSTS_EXAMPLE =
     );
 
 // For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries
     // Static registries only need to be looked up if you need to grab the tag data
@@ -442,8 +463,8 @@ public static final ResourceKey<BiomeModifier> REMOVE_SPAWN_COSTS_EXAMPLE =
     );
 
 // For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries
     // Static registries only need to be looked up if you need to grab the tag data
@@ -506,8 +527,8 @@ public static final ResourceKey<BiomeModifier> ADD_CARVERS_EXAMPLE =
     );
 
 // For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries
     // Static registries only need to be looked up if you need to grab the tag data
@@ -573,8 +594,8 @@ public static final ResourceKey<BiomeModifier> REMOVE_CARVERS_EXAMPLE =
     );
 
 // For some RegistrySetBuilder BUILDER
-//   being passed to DatapackBuiltinEntriesProvider
-//   in a listener for GatherDataEvent
+// being passed to DatapackBuiltinEntriesProvider
+// in a listener for GatherDataEvent
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries
     // Static registries only need to be looked up if you need to grab the tag data

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -9,12 +9,12 @@ Biome Modifiers are a data-driven system that allows for changing many aspects o
 
 - Players or pack developers:
   - [Applying Biome Modifiers](#Applying-Biome-Modifiers)
-  - [Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)
+  - [Built-in Neoforge Biome Modifiers](#Built-in-Biome-Modifiers)
 
 
 - Modders doing simple additions or removal biome modifications:
   - [Applying Biome Modifiers](#Applying-Biome-Modifiers)
-  - [Built-in Neoforge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)
+  - [Built-in Neoforge Biome Modifiers](#Built-in-Biome-Modifiers)
   - [Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)
 
 
@@ -28,7 +28,7 @@ Biome Modifiers are a data-driven system that allows for changing many aspects o
 
 To have NeoForge load a biome modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources, or in a [Datapack][datapacks]. Then, once NeoForge loads the biome modifier, it will read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing biome modifiers from mods can be overridden by datapacks having a new JSON file at the exact same location and name.
 
-The JSON file can be created by hand following the examples in the '[Built-in NeoForge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)' section or be datagenned as shown in the '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)' section.
+The JSON file can be created by hand following the examples in the '[Built-in NeoForge Biome Modifiers](#Built-in-Biome-Modifiers)' section or be datagenned as shown in the '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)' section.
 
 ## Built-in Biome Modifiers
 
@@ -70,7 +70,7 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 
 ### Add Features
 
-This biome modifier type adds `PlacedFeature`s (such as trees or ores) to biomes so that they can spawn during world generation. The modifier takes in the biome id or tag of the biomes the features are added to, a `PlacedFeature` id or tag to add to the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps) the features will be generated within.
+This biome modifier type adds `PlacedFeature`s (such as trees or ores) to biomes so that they can spawn during world generation. The modifier takes in the biome id or tag of the biomes the features are added to, a `PlacedFeature` id or tag to add to the selected biomes, and the [`GenerationStep.Decoration`](#Available-Values-for-Decoration-Steps) the features will be generated within.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>
@@ -137,7 +137,7 @@ Vanilla `PlacedFeature`s can be referenced in biome JSONs or added via biome mod
 
 ### Remove Features
 
-This biome modifier type removes features (such as trees or ores) from biomes so that they will no longer spawn during world generation. The modifier takes in the biome id or tag of the biomes the features are removed from, a `PlacedFeature` id or tag to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)s that the features will be removed from.
+This biome modifier type removes features (such as trees or ores) from biomes so that they will no longer spawn during world generation. The modifier takes in the biome id or tag of the biomes the features are removed from, a `PlacedFeature` id or tag to remove from the selected biomes, and the [`GenerationStep.Decoration`](#Available-Values-for-Decoration-Steps)s that the features will be removed from.
 
 <Tabs>
   <TabItem value="json" label="JSON" default>

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -26,21 +26,29 @@ Biome Modifiers are a data-driven system that allows for changing many aspects o
 
 ## Applying Biome Modifiers:
 
-Biome Modifiers are like a set of modifications to apply to a biome when the game loads. To have NeoForge load a Biome Modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a datapack. Then once NeoForge loads the Biome Modifier, it'll read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing Biome Modifiers from mods can be overridden by datapacks having a new JSON file at the exact same location and name.
+Biome Modifiers are like a set of modifications to apply to a biome when the game loads. To have NeoForge load a Biome Modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a Datapack. Then once NeoForge loads the Biome Modifier, it'll read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing Biome Modifiers from mods can be overridden by Datapacks having a new JSON file at the exact same location and name.
 
 The JSON file can be created by hand following the examples in the '[Built-in NeoForge Biome Modifiers](#Builtin-Neoforge-Biome-Modifiers)' section or be datagenned as shown in the '[Datagenning Biome Modifiers](#Datagenning-Biome-Modifiers)' section.
 
 ## Builtin Neoforge Biome Modifiers:
 
+These Biome Modifiers are registered by NeoForge for anyone to use. The JSON example and the Datagen code are provided as well as a brief explanation on what the modifier does.
+
 ### None
 
-This Biome Modifier has no operation and will do no modification. Pack makers and players can use this in a datapack to disable mods' Biome Modifiers by overriding their Biome Modifier jsons with the below:
+This Biome Modifier has no operation and will do no modification. Pack makers and players can use this in a Datapack to disable mods' Biome Modifiers by overriding their Biome Modifier jsons with the below. There is no Datagen code to make this modifier.
+
+<Tabs>
+  <TabItem value="json" label="JSON" default>
 
 ```json5
 {
   "type": "neoforge:none"
 }
 ```
+
+  </TabItem>
+</Tabs>
 
 ### Add Features
 
@@ -75,7 +83,7 @@ This Biome Modifier type adds features (such as trees or ores) to biomes so that
 ```java
 // Assume we have some PlacedFeature EXAMPLE_PLACED_FEATURE
 
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> ADD_FEATURES_EXAMPLE =
     ResourceKey.create(
@@ -149,7 +157,7 @@ This Biome Modifier type removes features (such as trees or ores) from biomes so
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> REMOVE_FEATURES_EXAMPLE =
     ResourceKey.create(
@@ -230,7 +238,7 @@ This Biome Modifier type adds mob spawns to biomes. The modifier takes in the `B
 ```java
 // Assume we have some EntityType EXAMPLE_ENTITY
 
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> ADD_SPAWNS_EXAMPLE =
     ResourceKey.create(
@@ -293,7 +301,7 @@ This Biome Modifier type removes mob spawns from biomes. The modifier takes in t
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> REMOVE_SPAWNS_EXAMPLE =
     ResourceKey.create(
@@ -362,7 +370,7 @@ The modifier takes in the `Biome` id or tag of the biomes the spawn costs are ad
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> ADD_SPAWN_COSTS_EXAMPLE =
     ResourceKey.create(
@@ -425,7 +433,7 @@ Allows for removing a Spawn Cost from a biome. Spawn Costs are a newer way of ma
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> REMOVE_SPAWN_COSTS_EXAMPLE =
     ResourceKey.create(
@@ -489,7 +497,7 @@ This Biome Modifier type allows adding Carver Caves and Ravines to biomes. (Thin
 ```java
 // Assume we have some ConfiguredWorldCarver EXAMPLE_CARVER
 
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> ADD_CARVERS_EXAMPLE =
     ResourceKey.create(
@@ -556,7 +564,7 @@ This Biome Modifier type allows removing Carver Caves and Ravines from biomes. (
   <TabItem value="datagen" label="Datagen">
 
 ```java
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> REMOVE_CARVERS_EXAMPLE =
     ResourceKey.create(
@@ -618,7 +626,7 @@ The `step` field in many of these JSONs are referring to GenerationStep.Decorati
 A `BiomeModifier` JSON can be created with [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. The JSON will be placed at `data/<modid>/neoforge/biome_modifier/<path>.json`.
 
 ```java
-// Define keys for datapack registry objects
+// Define keys for Datapack registry objects
 
 public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER =
     ResourceKey.create(

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -2,11 +2,11 @@
 
 Biome Modifiers are a data-driven system that allows for changing many aspects of a biome. Ranging from injecting or removing PlacedFeatures, adding or deleting mob spawns, changing the climate, and adjusting foliage and water color. NeoForge provides several default Biome Modifiers that covers the majority of use cases for both players and modders.
 
-For players and pack makers, you will want to see the [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers) section and [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) section.
+For players and pack makers, you will want to see the [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) section and [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers) section.
 
-For modders looking to do basic goals, you will want to see the [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers), [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) and possibly [#Datagenning-Biome-Modifiers](#Datagenning-Biome-Modifiers) sections for your mods.
+For modders looking to do basic goals, you will want to see the [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) section, [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers) section, and possibly the [#Datagenning-Biome-Modifiers](#Datagenning-Biome-Modifiers) section if you prefer to datagen.
 
-For modders looking to do advance custom Biome Modifiers, check out the [#Creating-Custom-Biome-Modifiers](#Creating-Custom-Biome-Modifiers) section.
+For modders looking to do advance custom Biome Modifiers, check out the [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) section and [#Creating-Custom-Biome-Modifiers](#Creating-Custom-Biome-Modifiers) section.
 
 ## Applying Biome Modifiers:
 

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -2,7 +2,7 @@
 
 Biome Modifiers are a data-driven system that allows for changing many aspects of a biome. Ranging from injecting or removing PlacedFeatures, adding or deleting mob spawns, changing the climate, and adjusting foliage and water color. NeoForge provides several default Biome Modifiers that covers the majority of use cases for both players and modders.
 
-For players, you will want to see the [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers) section and [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) section.
+For players and pack makers, you will want to see the [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers) section and [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) section.
 
 For modders looking to do basic goals, you will want to see the [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers), [#Applying-Biome-Modifiers](#Applying-Biome-Modifiers) and possibly [#Datagenning-Biome-Modifiers](#Datagenning-Biome-Modifiers) sections for your mods.
 

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -10,7 +10,7 @@ For modders looking to do advance custom Biome Modifiers, check out the [#Applyi
 
 ## Applying Biome Modifiers:
 
-To apply a Biome Modifier, the JSON file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a datapack. Neoforge will automatically detect and load the Biome Modifier and apply it to the game. Existing Biome Modifiers can be overridden by having a new JSON file at the exact same location and name.
+Biome Modifiers are like a set of modifications to apply to a biome when the game loads. To have NeoForge load a Biome Modifier JSON file into the game, the file will need to be under `data/<modid>/neoforge/biome_modifier/<path>.json` folder in the mod's resources or in a datapack. Then once NeoForge loads the Biome Modifier, it'll read its instructions and apply the described modifications to all target biomes when the world is loaded up. Pre-existing Biome Modifiers from mods can be overridden by datapacks having a new JSON file at the exact same location and name.
 
 The JSON file can be created by hand following the examples in [#Builtin-Neoforge-Biome-Modifiers](#Builtin-Neoforge-Biome-Modifiers) section or be datagenned as shown in [#Datagenning-Biome-Modifiers](#Datagenning-Biome-Modifiers) section.
 
@@ -18,18 +18,17 @@ The JSON file can be created by hand following the examples in [#Builtin-Neoforg
 
 ### None
 
-A no-op Biome Modifier type, whose jsons have the following format:
+This Biome Modifier has no operation and will do no modification. Pack makers and players can use this in a datapack to disable mods' Biome Modifiers by overriding their Biome Modifier jsons with the below:
+
 ```json5
 {
   "type": "neoforge:none"
 }
 ```
 
-This allows pack devs or server operators to disable mods' Biome Modifiers by overriding their Biome Modifier jsons with the above.
-
 ### Add Features
 
-This Biome Modifier type adds placed features to biomes. The modifier takes in the `Biome` id or tag of the biomes the features are added to, a `PlacedFeature` id or tag of the features to add to the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps) the features will be generated within.
+This Biome Modifier type adds features (such as trees or ores) to biomes so that they can spawn during world generation. The modifier takes in the `Biome` id or tag of the biomes the features are added to, a `PlacedFeature` id or tag of the features to add to the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps) the features will be generated within.
 
 ```json5
 {
@@ -51,9 +50,16 @@ This Biome Modifier type adds placed features to biomes. The modifier takes in t
 }
 ```
 
+#### Word of Warning
+
+- Avoid using Biome Modifiers to add vanilla placed features to biomes, as this may cause a feature cycle violation (the game will crash if two biomes have the same two features in their feature lists but in different orders within same GenerationStep). Placed features can be referenced in biome jsons or added via Biome Modifiers, but should not be used in both. Make a new copy of a vanilla Placed Feature is ideal for adding it safely to biomes.
+
+- Avoid adding the same placed feature with more than one Biome Modifier, as this can cause feature cycle violations.
+
+
 ### Remove Features
 
-This Biome Modifier type removes features from biomes. The modifier takes in the `Biome` id or tag of the biomes the features are removed from, a PlacedFeature id or tag of the features to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)s that the features will be removed from.
+This Biome Modifier type removes features (such as trees or ores) from biomes so that they will no longer spawn during world generation. The modifier takes in the `Biome` id or tag of the biomes the features are removed from, a `PlacedFeature` id or tag of the features to remove from the selected biomes, and the [`GenerationStep.Decoration`](#The-available-values-for-the-Decoration-steps)s that the features will be removed from.
 
 ```json5
 {
@@ -67,7 +73,7 @@ This Biome Modifier type removes features from biomes. The modifier takes in the
     // Can either be an id "minecraft:plains"
     // List of ids ["minecraft:plains", "minecraft:badlands", ...]
     // Or a tag "#c:is_overworld"
-    "features": "namespace:your_feature",
+    "features": "namespace:problematic_feature",
   
     // Optional field specifying a GenerationStep or list of GenerationSteps to remove features from, defaults to all if not specified.
     // See GenerationStep.Decoration enum in code for a list of valid enum names.
@@ -129,7 +135,9 @@ This Biome Modifier type removes mob spawns from biomes. The modifier takes in t
 
 ### Add Spawn Costs
 
-Allows for adding new Spawn Costs to biomes. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. The modifier takes in the `Biome` id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the mobs to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the mob. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based upon the charge provided for each entity spawned.
+Allows for adding new Spawn Costs to biomes. Spawn Costs are a newer way of making mobs spawn spread out in a biome to reduce clustering. It works by having the entities give off a `charge` that surrounds them and adds up with other entity's `charge`. Then when spawning, it looks for a spot where the total `charge` field at the location multiplied by the spawning entity's `charge` value is less than the spawning entity's `energy_budget`. This is an advanced way of spawning mobs so it is a good idea to reference the Soul Sand Valley Biome for existing values to borrow.
+
+The modifier takes in the `Biome` id or tag of the biomes the spawn costs are added to, the `EntityType` id or tag of the mobs to add spawn costs for, and the `MobSpawnSettings.MobSpawnCost` of the mob. The `MobSpawnCost` contains the energy budget, which indicates the maximum number of entities that can spawn in a location based upon the charge provided for each entity spawned.
 
 ```json5
 {
@@ -171,7 +179,7 @@ Allows for removing a Spawn Cost from a biome. Spawn Costs are a newer way of ma
 
 ### Add Legacy Carvers
 
-This Biome Modifier type allows adding old caves and ravines to biomes. This CANNOT add Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically ravines and old caves.
+This Biome Modifier type allows adding Carver Caves and Ravines to biomes. (Think of what caves looked like pre-Caves and Cliffs update) This CANNOT add Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically Ravines and Carver Caves.
 
 ```json5
 {
@@ -192,7 +200,7 @@ This Biome Modifier type allows adding old caves and ravines to biomes. This CAN
 
 ### Removing Legacy Carvers
 
-This Biome Modifier type allows removing old caves and ravines from biomes. This CANNOT remove Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically ravines and old caves.
+This Biome Modifier type allows removing Carver Caves and Ravines from biomes. (Think of what caves looked like pre-Caves and Cliffs update) This CANNOT remove Noise Caves to biomes because Noise Caves are baked into the dimension's Noise Setting system and not actually tied to biomes. The legacy carvers are specifically Ravines and Carver Caves.
 
 ```json5
 {
@@ -215,33 +223,34 @@ This Biome Modifier type allows removing old caves and ravines from biomes. This
 }
 ```
 
-### Word of Warning
-
-- Avoid using Biome Modifiers to add vanilla placed features to biomes, as this may cause a feature cycle violation (the game will crash if two biomes have the same two features in their feature lists but in different orders within same GenerationStep). Placed features can be referenced in biome jsons or added via Biome Modifiers, but should not be used in both. Make a new copy of a vanilla Placed Feature is ideal for adding it safely to biomes.
-
-
-- Avoid adding the same placed feature with more than one Biome Modifier, as this can cause feature cycle violations.
-
 ### The available values for the Decoration steps
 
-The `step` field in many of these JSONs are referring to GenerationStep.Decoration enum. This enum has the steps listed out in this order which is the same order that the game uses for generating during worldgen:
+The `step` field in many of these JSONs are referring to GenerationStep.Decoration enum. This enum has the steps listed out in this order which is the same order that the game uses for generating during worldgen. Try to put features in the stage that makes the most sense for them.
 
-    raw_generation
-    lakes
-    local_modifications
-    underground_structures
-    surface_structures
-    strongholds
-    underground_ores
-    underground_decoration
-    fluid_springs
-    vegetal_decoration
-    top_layer_modification
+|           Step           | Description                                                                             |
+|:------------------------:|:----------------------------------------------------------------------------------------|
+|     `raw_generation`     | First to run. This is used for special terrain-like features such as Small End Islands. |
+|         `lakes`          | Dedicated to spawning pond-like feature such as Lava Lakes.                             |
+|  `local_modifications`   | For modifications to terrain such as Geodes, Icebergs, Boulders, or Dripstone.          |
+| `underground_structures` | Used for small underground structure-like features such as Dungeons or Fossils.         |
+|   `surface_structures`   | For small surface only structure-like features such as Desert Wells.                    |
+|      `strongholds`       | Dedicated for Stronghold structures. No feature is added here in unmodified Minecraft.  |
+|    `underground_ores`    | The step for all Ores and Veins to be added to. This includes Gold, Dirt, Granite, etc. |
+| `underground_decoration` | Used typically for decorating caves. Dripstone Cluster and Sculk Vein are here.         |
+|     `fluid_springs`      | The small Lavafalls and Waterfalls comes from features in this stage.                   |
+|   `vegetal_decoration`   | Nearly all plants (flowers, trees, vines, and more) are added to this stage.            |
+| `top_layer_modification` | Last to run. Used for placing Snow and Ice on the surface of cold biomes.               |
 
 
 ## Datagenning Biome Modifiers:
 
 A `BiomeModifier` can be with [data generation][datagen] by passing a `RegistrySetBuilder` to `DatapackBuiltinEntriesProvider`. Biome Modifiers are located within `data/<modid>/neoforge/biome_modifier/<path>.json` All Biome Modifiers contain a `type` key that references the id of the `MapCodec` used for the Biome Modifier. All other settings provided by the Biome Modifier are added as additional keys on the root object.
+
+Biome Modifiers are made up of three parts:
+
+- The [datapack registered][datareg] `BiomeModifier` used to modify the biome builder.
+- The [statically registered][staticreg] `MapCodec` that encodes and decodes the modifiers.
+- The JSON that constructs the `BiomeModifier`, using the registered id of the `MapCodec` as the indexable type.
 
 ```java
 // Define keys for datapack registry objects
@@ -593,12 +602,6 @@ BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
 ```
 
 ## Creating Custom Biome Modifiers:
-
-Biome Modifiers are made up of three parts:
-
-- The [datapack registered][datareg] `BiomeModifier` used to modify the biome builder.
-- The [statically registered][staticreg] `MapCodec` that encodes and decodes the modifiers.
-- The JSON that constructs the `BiomeModifier`, using the registered id of the `MapCodec` as the indexable type.
 
 ### The `BiomeModifier` Implementation
 


### PR DESCRIPTION
This is based off of the work from both ChampionAsh and the Gemwire wiki:
https://github.com/ChampionAsh5357/NeoForge-Docs/blob/feat/worldgen-primer/docs/worldgen/biomes/biomemodifiers.md
https://forge.gemwire.uk/wiki/Biome_Modifiers

My goal here was to take an approach to try and keep the docs more simple for readers and push the more technical stuff into the data generation/custom biome modifier sections. The reason for this is this document is going to be linked to both pack makers and beginner modders who may not be datagenning.

To help ease into the docs, it starts off with a brief overview of what Biome Modifiers are and can do. And then it lists which section to check out for if the reader is a player/pack maker, a modder with basic needs, or an advanced modder that needs something custom. This way the reader knows exactly which section is actually relevant to them.

That's why I pushed the datagen into it's own section as it is not relevant to players/pack makers and would just be visual noise. And datagenners don't need to know what the JSON looks like as the codec will make it for them so the JSON would've been visual noise for the modder. And lastly, the actual implementation details of the Biome Modifier itself with the phases and codecs is only relevant to people making their own biome modifier from scratch.

------------------
Preview URL: https://pr-161.neoforged-docs-previews.pages.dev