### PR TITLE
Fix Advancements page

### DIFF
--- a/docs/resources/server/advancements.md
+++ b/docs/resources/server/advancements.md
@@ -231,7 +231,7 @@ builder.rewards(
     // Alternatively, use addExperience() to add to an existing builder.
     AdvancementRewards.Builder.experience(100)
     // Alternatively, use loot() to create a new builder.
-    .addLootTable(ResourceLocation.fromNamespaceAndPath("minecraft", "chests/igloo"))
+    .addLootTable(ResourceKey.create(Registries.LOOT_TABLE, ResourceLocation.fromNamespaceAndPath("minecraft", "blocks/dirt")))
     // Alternatively, use recipe() to create a new builder.
     .addRecipe(ResourceLocation.fromNamespaceAndPath("minecraft", "iron_ingot"))
     // Alternatively, use function() to create a new builder.

--- a/docs/resources/server/advancements.md
+++ b/docs/resources/server/advancements.md
@@ -231,7 +231,7 @@ builder.rewards(
     // Alternatively, use addExperience() to add to an existing builder.
     AdvancementRewards.Builder.experience(100)
     // Alternatively, use loot() to create a new builder.
-    .addLootTable(ResourceKey.create(Registries.LOOT_TABLE, ResourceLocation.fromNamespaceAndPath("minecraft", "blocks/dirt")))
+    .addLootTable(ResourceKey.create(Registries.LOOT_TABLE, ResourceLocation.fromNamespaceAndPath("minecraft", "chests/igloo")))
     // Alternatively, use recipe() to create a new builder.
     .addRecipe(ResourceLocation.fromNamespaceAndPath("minecraft", "iron_ingot"))
     // Alternatively, use function() to create a new builder.

--- a/docs/resources/server/advancements.md
+++ b/docs/resources/server/advancements.md
@@ -247,7 +247,7 @@ builder.requirements(AdvancementRequirements.allOf(List.of("pickup_dirt")));
 
 // Save the advancement to disk, using the given resource location. This returns an AdvancementHolder,
 // which may be stored in a variable and used as a parent by other advancement builders.
-builder.save(saver, ResourceLocation.fromNamespaceAndPath("examplemod", "example_advancement"), existingFileHelper);
+builder.save(consumer, ResourceLocation.fromNamespaceAndPath("examplemod", "example_advancement"), existingFileHelper);
 ```
 
 Of course, don't forget to add your provider to the `GatherDataEvent`:

--- a/docs/resources/server/advancements.md
+++ b/docs/resources/server/advancements.md
@@ -247,7 +247,7 @@ builder.requirements(AdvancementRequirements.allOf(List.of("pickup_dirt")));
 
 // Save the advancement to disk, using the given resource location. This returns an AdvancementHolder,
 // which may be stored in a variable and used as a parent by other advancement builders.
-builder.save(consumer, ResourceLocation.fromNamespaceAndPath("examplemod", "example_advancement"), existingFileHelper);
+builder.save(saver, ResourceLocation.fromNamespaceAndPath("examplemod", "example_advancement"), existingFileHelper);
 ```
 
 Of course, don't forget to add your provider to the `GatherDataEvent`:

--- a/docs/resources/server/advancements.md
+++ b/docs/resources/server/advancements.md
@@ -146,7 +146,7 @@ Whenever the action being checked is performed, the `#trigger` method defined by
 // Again, EXAMPLE_TRIGGER is a supplier for the registered instance of the custom criterion trigger
 public void performExampleAction(ServerPlayer player, additionalContextParametersHere) {
     // Run code to perform action here
-    EXAMPLE_TRIGGER.value().trigger(player, additionalContextParametersHere);
+    EXAMPLE_TRIGGER.get().trigger(player, additionalContextParametersHere);
 }
 ```
 


### PR DESCRIPTION
This PR fix two things in the [advancements](https://docs.neoforged.net/docs/resources/server/advancements/) page.

## Supplier<ExampleCriterionTrigger>#value()
In the docs, there is written that for the [`performExampleAction`](https://docs.neoforged.net/docs/resources/server/advancements/#calling-criterion-triggers), we need to use get our registry but with the  non-existent `value()` method  and it should be replaced with the `get()` method.

## Parameter name for [AdvancementGenerator](https://docs.neoforged.net/docs/resources/server/advancements/#data-generation) 
This is a minor change. To datagen an advancement, we need to create a class that implements `AdvancementProvider.AdvancementGenerator`. This interface have the `generate` method with theses paramaters `HolderLookup.Provider registries`, `Consumer<AdvancementHolder> saver`, `ExistingFileHelper existingFileHelper` but in the docs, the parameter `consumer` is named `saver`

## AdvancementRewards.Builder#addLootTable() require a ResourceKey
In the docs, to add a lootTable, it says that the function `AdvancementRewards.Builder#addLootTable()` require a ResourceLocation but it actually need a `ResourceKey<LootTable>`