### PR TITLE
Update porting primers to .github repo link

### DIFF
--- a/docs/legacy/porting.md
+++ b/docs/legacy/porting.md
@@ -1,27 +1,31 @@
-# Porting to Minecraft 1.20
+# Porting to Minecraft 1.21.3
 
 Here you can find a list of primers on how to port from old versions to the current version. Some versions are lumped together since that particular version never saw much usage.
 
-|    From -> To         |               Primer                    |
-|:---------------------:|:----------------------------------------|
-| 1.12 -> 1.13/1.14     | [Primer by williewillus][112to114]      |
-| 1.14 -> 1.15          | [Primer by williewillus][114to115]      |
-| 1.15 -> 1.16          | [Primer by 50ap5ud5][115to116]          |
-| 1.16 -> 1.17          | [Primer by 50ap5ud5][116to117]          |
-| 1.19.2 -> 1.19.3      | [Primer by ChampionAsh5357][1192to1193] |
-| 1.19.3 -> 1.19.4      | [Primer by ChampionAsh5357][1193to1194] |
-| 1.19.4 -> 1.20.0      | [Primer by ChampionAsh5357][1194to120]  |
-| 1.20.4 -> 1.20.5/6    | [Primer by ChampionAsh5357][1204to1205] |
-| 1.20.6 -> 1.21/1.21.1 | [Primer by ChampionAsh5357][1206to121]  |
-| 1.21.1 -> 1.21.2/3    | [Primer by ChampionAsh5357][1211to1212] |
+|    From -> To      |               Primer                    |
+|:------------------:|:----------------------------------------|
+| 1.12 -> 1.13/1.14  | [Primer by williewillus][112to114]      |
+| 1.14 -> 1.15       | [Primer by williewillus][114to115]      |
+| 1.15 -> 1.16       | [Primer by 50ap5ud5][115to116]          |
+| 1.16 -> 1.17       | [Primer by 50ap5ud5][116to117]          |
+| 1.19.2 -> 1.19.3   | [Primer by ChampionAsh5357][1192to1193] |
+| 1.19.3 -> 1.19.4   | [Primer by ChampionAsh5357][1193to1194] |
+| 1.19.4 -> 1.20     | [Primer by ChampionAsh5357][1194to120]  |
+| 1.20.4 -> 1.20.5   | [Primer by ChampionAsh5357][1204to1205] |
+| 1.20.5 -> 1.20.6   | [Primer by ChampionAsh5357][1205to1206] |
+| 1.20.6 -> 1.21     | [Primer by ChampionAsh5357][1206to121]  |
+| 1.21   -> 1.21.1   | [Primer by ChampionAsh5357][121to1211]  |
+| 1.21.1 -> 1.21.2/3 | [Primer by ChampionAsh5357][1211to1212] |
 
 [112to114]: https://gist.github.com/williewillus/353c872bcf1a6ace9921189f6100d09a
 [114to115]: https://gist.github.com/williewillus/30d7e3f775fe93c503bddf054ef3f93e
 [115to116]: https://gist.github.com/50ap5ud5/f4e70f0e8faeddcfde6b4b1df70f83b8
 [116to117]: https://gist.github.com/50ap5ud5/beebcf056cbdd3c922cc8993689428f4
-[1192to1193]: https://gist.github.com/ChampionAsh5357/c21724bafbc630da2ed8899fe0c1d226
-[1193to1194]: https://gist.github.com/ChampionAsh5357/163a75e87599d19ee6b4b879821953e8
-[1194to120]: https://gist.github.com/ChampionAsh5357/cf818acc53ffea6f4387fe28c2977d56
-[1204to1205]: https://gist.github.com/ChampionAsh5357/53b04132e292aa12638d339abfabf955
-[1206to121]: https://gist.github.com/ChampionAsh5357/d895a7b1a34341e19c80870720f9880f
+[1192to1193]: https://github.com/neoforged/.github/blob/main/primers/1.19.3/index.md
+[1193to1194]: https://github.com/neoforged/.github/blob/main/primers/1.19.4/index.md
+[1194to120]: https://github.com/neoforged/.github/blob/main/primers/1.20/index.md
+[1204to1205]: https://github.com/neoforged/.github/blob/main/primers/1.20.5/index.md
+[1205to1206]: https://github.com/neoforged/.github/blob/main/primers/1.20.6/index.md
+[1206to121]: https://github.com/neoforged/.github/blob/main/primers/1.21/index.md
+[121to1211]: https://github.com/neoforged/.github/blob/main/primers/1.21.1/index.md
 [1211to1212]: https://github.com/neoforged/.github/blob/main/primers/1.21.2/index.md

--- a/versioned_docs/version-1.20.4/legacy/porting.md
+++ b/versioned_docs/version-1.20.4/legacy/porting.md
@@ -1,21 +1,21 @@
-# Porting to Minecraft 1.20
+# Porting to Minecraft 1.20.4
 
 Here you can find a list of primers on how to port from old versions to the current version. Some versions are lumped together since that particular version never saw much usage.
 
-|    From -> To     |               Primer                    |
-|:-----------------:|:----------------------------------------|
-| 1.12 -> 1.13/1.14 | [Primer by williewillus][112to114]      |
-| 1.14 -> 1.15      | [Primer by williewillus][114to115]      |
-| 1.15 -> 1.16      | [Primer by 50ap5ud5][115to116]          |
-| 1.16 -> 1.17      | [Primer by 50ap5ud5][116to117]          |
-| 1.19.2 -> 1.19.3  | [Primer by ChampionAsh5357][1192to1193] |
-| 1.19.3 -> 1.19.4  | [Primer by ChampionAsh5357][1193to1194] |
-| 1.19.4 -> 1.20.0  | [Primer by ChampionAsh5357][1194to120] |
+|    From -> To      |               Primer                    |
+|:------------------:|:----------------------------------------|
+| 1.12 -> 1.13/1.14  | [Primer by williewillus][112to114]      |
+| 1.14 -> 1.15       | [Primer by williewillus][114to115]      |
+| 1.15 -> 1.16       | [Primer by 50ap5ud5][115to116]          |
+| 1.16 -> 1.17       | [Primer by 50ap5ud5][116to117]          |
+| 1.19.2 -> 1.19.3   | [Primer by ChampionAsh5357][1192to1193] |
+| 1.19.3 -> 1.19.4   | [Primer by ChampionAsh5357][1193to1194] |
+| 1.19.4 -> 1.20     | [Primer by ChampionAsh5357][1194to120]  |
 
 [112to114]: https://gist.github.com/williewillus/353c872bcf1a6ace9921189f6100d09a
 [114to115]: https://gist.github.com/williewillus/30d7e3f775fe93c503bddf054ef3f93e
 [115to116]: https://gist.github.com/50ap5ud5/f4e70f0e8faeddcfde6b4b1df70f83b8
 [116to117]: https://gist.github.com/50ap5ud5/beebcf056cbdd3c922cc8993689428f4
-[1192to1193]: https://gist.github.com/ChampionAsh5357/c21724bafbc630da2ed8899fe0c1d226
-[1193to1194]: https://gist.github.com/ChampionAsh5357/163a75e87599d19ee6b4b879821953e8
-[1194to120]: https://gist.github.com/ChampionAsh5357/cf818acc53ffea6f4387fe28c2977d56
+[1192to1193]: https://github.com/neoforged/.github/blob/main/primers/1.19.3/index.md
+[1193to1194]: https://github.com/neoforged/.github/blob/main/primers/1.19.4/index.md
+[1194to120]: https://github.com/neoforged/.github/blob/main/primers/1.20/index.md

--- a/versioned_docs/version-1.20.6/legacy/porting.md
+++ b/versioned_docs/version-1.20.6/legacy/porting.md
@@ -1,4 +1,4 @@
-# Porting to Minecraft 1.20
+# Porting to Minecraft 1.20.6
 
 Here you can find a list of primers on how to port from old versions to the current version. Some versions are lumped together since that particular version never saw much usage.
 
@@ -10,14 +10,16 @@ Here you can find a list of primers on how to port from old versions to the curr
 | 1.16 -> 1.17       | [Primer by 50ap5ud5][116to117]          |
 | 1.19.2 -> 1.19.3   | [Primer by ChampionAsh5357][1192to1193] |
 | 1.19.3 -> 1.19.4   | [Primer by ChampionAsh5357][1193to1194] |
-| 1.19.4 -> 1.20.0   | [Primer by ChampionAsh5357][1194to120]  |
-| 1.20.4 -> 1.20.5/6 | [Primer by ChampionAsh5357][1204to1205] |
+| 1.19.4 -> 1.20     | [Primer by ChampionAsh5357][1194to120]  |
+| 1.20.4 -> 1.20.5   | [Primer by ChampionAsh5357][1204to1205] |
+| 1.20.5 -> 1.20.6   | [Primer by ChampionAsh5357][1205to1206] |
 
 [112to114]: https://gist.github.com/williewillus/353c872bcf1a6ace9921189f6100d09a
 [114to115]: https://gist.github.com/williewillus/30d7e3f775fe93c503bddf054ef3f93e
 [115to116]: https://gist.github.com/50ap5ud5/f4e70f0e8faeddcfde6b4b1df70f83b8
 [116to117]: https://gist.github.com/50ap5ud5/beebcf056cbdd3c922cc8993689428f4
-[1192to1193]: https://gist.github.com/ChampionAsh5357/c21724bafbc630da2ed8899fe0c1d226
-[1193to1194]: https://gist.github.com/ChampionAsh5357/163a75e87599d19ee6b4b879821953e8
-[1194to120]: https://gist.github.com/ChampionAsh5357/cf818acc53ffea6f4387fe28c2977d56
-[1204to1205]: https://gist.github.com/ChampionAsh5357/53b04132e292aa12638d339abfabf955
+[1192to1193]: https://github.com/neoforged/.github/blob/main/primers/1.19.3/index.md
+[1193to1194]: https://github.com/neoforged/.github/blob/main/primers/1.19.4/index.md
+[1194to120]: https://github.com/neoforged/.github/blob/main/primers/1.20/index.md
+[1204to1205]: https://github.com/neoforged/.github/blob/main/primers/1.20.5/index.md
+[1205to1206]: https://github.com/neoforged/.github/blob/main/primers/1.20.6/index.md

--- a/versioned_docs/version-1.21.1/legacy/porting.md
+++ b/versioned_docs/version-1.21.1/legacy/porting.md
@@ -1,4 +1,4 @@
-# Porting to Minecraft 1.20
+# Porting to Minecraft 1.21.1
 
 Here you can find a list of primers on how to port from old versions to the current version. Some versions are lumped together since that particular version never saw much usage.
 
@@ -10,16 +10,20 @@ Here you can find a list of primers on how to port from old versions to the curr
 | 1.16 -> 1.17       | [Primer by 50ap5ud5][116to117]          |
 | 1.19.2 -> 1.19.3   | [Primer by ChampionAsh5357][1192to1193] |
 | 1.19.3 -> 1.19.4   | [Primer by ChampionAsh5357][1193to1194] |
-| 1.19.4 -> 1.20.0   | [Primer by ChampionAsh5357][1194to120]  |
-| 1.20.4 -> 1.20.5/6 | [Primer by ChampionAsh5357][1204to1205] |
+| 1.19.4 -> 1.20     | [Primer by ChampionAsh5357][1194to120]  |
+| 1.20.4 -> 1.20.5   | [Primer by ChampionAsh5357][1204to1205] |
+| 1.20.5 -> 1.20.6   | [Primer by ChampionAsh5357][1205to1206] |
 | 1.20.6 -> 1.21     | [Primer by ChampionAsh5357][1206to121]  |
+| 1.21   -> 1.21.1   | [Primer by ChampionAsh5357][121to1211]  |
 
 [112to114]: https://gist.github.com/williewillus/353c872bcf1a6ace9921189f6100d09a
 [114to115]: https://gist.github.com/williewillus/30d7e3f775fe93c503bddf054ef3f93e
 [115to116]: https://gist.github.com/50ap5ud5/f4e70f0e8faeddcfde6b4b1df70f83b8
 [116to117]: https://gist.github.com/50ap5ud5/beebcf056cbdd3c922cc8993689428f4
-[1192to1193]: https://gist.github.com/ChampionAsh5357/c21724bafbc630da2ed8899fe0c1d226
-[1193to1194]: https://gist.github.com/ChampionAsh5357/163a75e87599d19ee6b4b879821953e8
-[1194to120]: https://gist.github.com/ChampionAsh5357/cf818acc53ffea6f4387fe28c2977d56
-[1204to1205]: https://gist.github.com/ChampionAsh5357/53b04132e292aa12638d339abfabf955
-[1206to121]: https://gist.github.com/ChampionAsh5357/d895a7b1a34341e19c80870720f9880f
+[1192to1193]: https://github.com/neoforged/.github/blob/main/primers/1.19.3/index.md
+[1193to1194]: https://github.com/neoforged/.github/blob/main/primers/1.19.4/index.md
+[1194to120]: https://github.com/neoforged/.github/blob/main/primers/1.20/index.md
+[1204to1205]: https://github.com/neoforged/.github/blob/main/primers/1.20.5/index.md
+[1205to1206]: https://github.com/neoforged/.github/blob/main/primers/1.20.6/index.md
+[1206to121]: https://github.com/neoforged/.github/blob/main/primers/1.21/index.md
+[121to1211]: https://github.com/neoforged/.github/blob/main/primers/1.21.1/index.md


### PR DESCRIPTION
Updates the primers to use the links within the `.github` repo as necessary. Also fixes the porting header to the last version the docs are written for.