### PR TITLE
Add supported versions in version label

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,8 +47,17 @@ const config = {
           includeCurrentVersion: true,
           versions: {
             current: {
-              label: "1.21.x",
+              label: "1.21.2 - 1.21.3",
             },
+            "1.21.1": {
+              label: "1.21 - 1.21.1"
+            },
+            "1.20.6": {
+              label: "1.20.5 - 1.20.6"
+            },
+            "1.20.4": {
+              label: "1.20.3 - 1.20.4"
+            }
           },
         },
         theme: {


### PR DESCRIPTION
Closes #207 

The supported Minecraft versions for the live documentation are now listed in the version dropdown.