### PR TITLE
server recipes: make group non-final

### DIFF
--- a/versioned_docs/version-1.21.1/resources/server/recipes/index.md
+++ b/versioned_docs/version-1.21.1/resources/server/recipes/index.md
@@ -429,7 +429,7 @@ public abstract class SimpleRecipeBuilder implements RecipeBuilder {
     protected final ItemStack result;
     protected final Map<String, Criterion<?>> criteria = new LinkedHashMap<>();
     @Nullable
-    protected final String group;
+    protected String group;
 
     // It is common for constructors to accept the result item stack.
     // Alternatively, static builder methods are also possible.


### PR DESCRIPTION
`group` is marked final, but is not a constructor parameter. since it's optional, it shouldnt be final

------------------
Preview URL: https://pr-210.neoforged-docs-previews.pages.dev