### PR TITLE
[1.21.4] Update usage of `GatherDataEvent` and the `create*` methods

### DIFF
--- a/docs/advanced/featureflags.md
+++ b/docs/advanced/featureflags.md
@@ -262,7 +262,7 @@ Feature packs can be generated during regular mod datagen. This is best used in 
 
 ```java
 @SubscribeEvent
-public static void gatherData(final GatherDataEvent event) {
+public static void gatherData(final GatherDataEvent.Client event) {
     DataGenerator generator = event.getGenerator();
     
     // To generate a feature pack, you must first obtain a pack generator instance for the desired pack.

--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -312,23 +312,24 @@ Finally, we use our `RegistrySetBuilder` in an actual data provider, and registe
 
 ```java
 @SubscribeEvent
-public static void onGatherData(GatherDataEvent event) {
-    CompletableFuture<HolderLookup.Provider> lookupProvider = event.getGenerator().addProvider(
-        // Only run datapack generation when server data is being generated
-        event.includeServer(),
-        // Create the provider
-        output -> new DatapackBuiltinEntriesProvider(
-            output,
-            event.getLookupProvider(),
-            // Our registry set builder to generate the data from.
-            new RegistrySetBuilder().add(...),
-            // A set of mod ids we are generating. Usually only your own mod id.
-            Set.of("yourmodid")
-        )
-    ).getRegistryProvider();
-    
-    // Use the lookup provider generated from your datapack entries as input
-    //   to all other data providers.
+public static void onGatherData(GatherDataEvent.Client event) {
+    // Adds the generated registry objects to the current lookup provider for use
+    // in other datagen.
+    this.createDatapackRegistryObjects(
+        // Our registry set builder to generate the data from.
+        new RegistrySetBuilder().add(...),
+        // (Optional) A biconsumer that takes in any conditions to load the object
+        // associated with the resource key
+        conditions -> {
+            conditions.accept(resourceKey, condition);
+        },
+        // (Optional) A set of mod ids we are generating the entries for
+        // By default, supplies the mod id of the current mod container.
+        Set.of("yourmodid")
+    );
+
+    // You can use the lookup provider with your generated entries by either calling one
+    // of the `#create*` methods or grabbing the actual lookup via `#getLookupProvider`
     // ...
 }
 ```

--- a/docs/items/armor.md
+++ b/docs/items/armor.md
@@ -347,14 +347,8 @@ public class MyEquipmentInfoProvider implements DataProvider {
 
 // Listening to the mod event bus
 @SubscribeEvent
-public static void gatherData(GatherDataEvent event) {
-    PackOutput output = generator.getPackOutput();
-
-    // Other providers here
-    event.getGenerator().addProvider(
-        event.includeClient(),
-        new MyEquipmentInfoProvider(output)
-    );
+public static void gatherData(GatherDataEvent.Client event) {
+    event.createProvider(MyEquipmentInfoProvider::new);
 }
 ```
 

--- a/docs/resources/client/i18n.md
+++ b/docs/resources/client/i18n.md
@@ -136,7 +136,7 @@ Language files can be [datagenned][datagen]. To do so, extend the `LanguageProvi
 public class MyLanguageProvider extends LanguageProvider {
     public MyLanguageProvider(PackOutput output) {
         super(
-            // Provided by the GatherDataEvent.
+            // Provided by the `GatherDataEvent.Client`.
             output,
             // Your mod id.
             "examplemod",
@@ -177,7 +177,7 @@ public class MyLanguageProvider extends LanguageProvider {
 }
 ```
 
-Then, register the provider like any other provider in the `GatherDataEvent`.
+Then, register the provider like any other provider in the `GatherDataEvent.Client`.
 
 [datacomponent]: ../../items/datacomponents.md
 [datagen]: ../index.md#data-generation

--- a/docs/resources/client/models/datagen.md
+++ b/docs/resources/client/models/datagen.md
@@ -117,15 +117,8 @@ And like all data providers, don't forget to register your provider to the event
 
 ```java
 @SubscribeEvent
-public static void gatherData(GatherDataEvent event) {
-    DataGenerator generator = event.getGenerator();
-    PackOutput output = generator.getPackOutput();
-
-    // other providers here
-    generator.addProvider(
-        event.includeClient(),
-        new ExampleModelProvider(output)
-    );
+public static void gatherData(GatherDataEvent.Client event) {
+    event.createProvider(ExampleModelProvider::new);
 }
 ```
 

--- a/docs/resources/client/particles.md
+++ b/docs/resources/client/particles.md
@@ -136,7 +136,7 @@ Particle definition files can also be [datagenned][datagen] by extending `Partic
 
 ```java
 public class MyParticleDescriptionProvider extends ParticleDescriptionProvider {
-    // Get the parameters from GatherDataEvent.
+    // Get the parameters from `GatherDataEvent.Client`.
     public MyParticleDescriptionProvider(PackOutput output) {
         super(output);
     }
@@ -166,19 +166,12 @@ public class MyParticleDescriptionProvider extends ParticleDescriptionProvider {
 }
 ```
 
-Don't forget to add the provider to the `GatherDataEvent`:
+Don't forget to add the provider to the `GatherDataEvent.Client`:
 
 ```java
 @SubscribeEvent
-public static void gatherData(GatherDataEvent event) {
-    DataGenerator generator = event.getGenerator();
-    PackOutput output = generator.getPackOutput();
-
-    // other providers here
-    generator.addProvider(
-        event.includeClient(),
-        new MyParticleDescriptionProvider(output)
-    );
+public static void gatherData(GatherDataEvent.Client event) {
+    event.createProvider(MyParticleDescriptionProvider::new);
 }
 ```
 

--- a/docs/resources/client/sounds.md
+++ b/docs/resources/client/sounds.md
@@ -246,7 +246,7 @@ Sound files themselves can of course not be [datagenned][datagen], but `sounds.j
 
 ```java
 public class MySoundDefinitionsProvider extends SoundDefinitionsProvider {
-    // Parameters can be obtained from GatherDataEvent.
+    // Parameters can be obtained from `GatherDataEvent.Client`.
     public MySoundDefinitionsProvider(PackOutput output) {
         // Use your actual mod id instead of "examplemod".
         super(output, "examplemod");
@@ -291,15 +291,8 @@ As with every data provider, don't forget to register the provider to the event:
 
 ```java
 @SubscribeEvent
-public static void gatherData(GatherDataEvent event) {
-    DataGenerator generator = event.getGenerator();
-    PackOutput output = generator.getPackOutput();
-
-    // other providers here
-    generator.addProvider(
-        event.includeClient(),
-        new MySoundDefinitionsProvider(output)
-    );
+public static void gatherData(GatherDataEvent.Client event) {
+    event.createProvider(MySoundDefinitionsProvider::new);
 }
 ```
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -80,7 +80,13 @@ Data generation, colloquially known as datagen, is a way to programmatically gen
 
 Datagen is run through the Data run configuration, which is generated for you alongside the Client and Server run configurations. The data run configuration follows the [mod lifecycle][lifecycle] until after the registry events are fired. It then fires one of the [`GatherDataEvent`s][event], in which you can register your to-be-generated objects in the form of data providers, writes said objects to disk, and ends the process.
 
-There are two subtypes which operate on the [**physical side**][physicalside]: `GatherDataEvent.Client` and `GatherDataEvent.Server`.  `GatherDataEvent.Client` should contain all providers to generate while `GatherDataEvent.Server` should only contain the providers used to generate datapack entries. As such, all examples shown will use `GatherDataEvent.Client`, as that event is also what is fired by the default `clientData` configuration provided by the MDK.
+There are two subtypes which operate on the [**physical side**][physicalside]: `GatherDataEvent.Client` and `GatherDataEvent.Server`.  `GatherDataEvent.Client` may contain all providers to generate. `GatherDataEvent.Server`, on the other hand, may only contain the providers used to generate datapack entries.
+
+:::note
+There are two recommendations on how to register your providers. The former is to register all of them in `GatherDataEvent.Client` and use the `runClientData` task to generate the data. The latter is to register client providers to `GatherDataEvent.Client` and server providers to `GatherDataEvent.Server`, generating them by running the `runClientData` and `runServerData` tasks, respectively.
+
+As the MDK uses the former solution by setting up the default `clientData` configuration, all examples shown will use the former by registering all providers to `GatherDataEvent.Client`.
+:::
 
 All data providers extend the `DataProvider` interface and usually require one method to be overridden. The following is a list of noteworthy data generators Minecraft and NeoForge offer (the linked articles add further information, such as helper methods):
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -78,7 +78,9 @@ _See also: [`pack.mcmeta` (Resource Pack)][packmcmetaresourcepack] and [`pack.mc
 
 Data generation, colloquially known as datagen, is a way to programmatically generate JSON resource files, in order to avoid the tedious and error-prone process of writing them by hand. The name is a bit misleading, as it works for assets as well as data.
 
-Datagen is run through the Data run configuration, which is generated for you alongside the Client and Server run configurations. The data run configuration follows the [mod lifecycle][lifecycle] until after the registry events are fired. It then fires the [`GatherDataEvent`][event], in which you can register your to-be-generated objects in the form of data providers, writes said objects to disk, and ends the process.
+Datagen is run through the Data run configuration, which is generated for you alongside the Client and Server run configurations. The data run configuration follows the [mod lifecycle][lifecycle] until after the registry events are fired. It then fires one of the [`GatherDataEvent`s][event], in which you can register your to-be-generated objects in the form of data providers, writes said objects to disk, and ends the process.
+
+There are two subtypes which operate on the [**physical side**][physicalside]: `GatherDataEvent.Client` and `GatherDataEvent.Server`.  `GatherDataEvent.Client` should contain all providers to generate while `GatherDataEvent.Server` should only contain the providers used to generate datapack entries. As such, all examples shown will use `GatherDataEvent.Client`, as that event is also what is fired by the default `clientData` configuration provided by the MDK.
 
 All data providers extend the `DataProvider` interface and usually require one method to be overridden. The following is a list of noteworthy data generators Minecraft and NeoForge offer (the linked articles add further information, such as helper methods):
 
@@ -115,36 +117,43 @@ public class MyRecipeProvider extends RecipeProvider {
 @EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD, modid = "examplemod")
 public class MyDatagenHandler {
     @SubscribeEvent
-    public static void gatherData(GatherDataEvent event) {
-        // Data generators may require some of these as constructor parameters.
-        // See below for more details on each of these.
-        DataGenerator generator = event.getGenerator();
-        PackOutput output = generator.getPackOutput();
-        CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
+    public static void gatherData(GatherDataEvent.Client event) {
+        // Data providers should start by calling event.createDatapackRegistryObjects(...)
+        // to register their datapack registry objects. This allows other providers
+        // to use these objects during their own data generation.
+
+        // From there, providers can generally be registered using event.createProvider(...),
+        // which acts as a function that provides the PackOutput and optionally the
+        // CompletableFuture<HolderLookup.Provider>.
 
         // Register the provider.
-        generator.addProvider(
-                // A boolean that determines whether the data should actually be generated.
-                // The event provides methods that determine this:
-                // event.includeClient(), event.includeServer(),
-                // event.includeDev() and event.includeReports().
-                // Since recipes are server data, we only run them in a server datagen.
-                event.includeServer(),
-                // Our provider.
-                new MyRecipeProvider(output, lookupProvider)
-        );
+        event.createProvider(MyRecipeProvider::new);
         // Other data providers here.
+
+        // If you want to create a datapack within the global pack, you can call
+        // DataGenerator#getBuiltinDatapack. From there, you must use the
+        // PackGenerator#addProvider method to add any providers to that pack.
+        DataGenerator.PackGenerator examplePack = event.getGenerator().getBuiltinDatapack(
+            true, // Should always be true.
+            "examplemod", // The mod id.
+            "example_pack" // The name of the pack.
+        );
+        
+        examplePack.addProvider(output -> ...);
     }
 }
 ```
 
-The event offers some context for you to use:
+The event offers some helpers and context for you to use:
 
+- `event.createDatapackRegistryObjects(...)` creates and registers a `DatapackBuiltinEntriesProvider` using the provided `RegistrySetBuilder`. It also forces any future use of the lookup provider to contain your datagenned entries.
+- `event.createProvider(...)` registers a provider by providing the `PackOutput` and optionally the `CompletableFuture<HolderLookup.Provider>` as part of a lambda.
+- `event.createBlockAndItemTags(...)` registers a `TagsProvider<Block>` and `TagsProvider<Item>` by constructing the `TagsProvider<Item>` using the `TagsProvider<Block>`.
 - `event.getGenerator()` returns the `DataGenerator` that you register the providers to.
 - `event.getPackOutput()` returns a `PackOutput` that is used by some providers to determine their file output location.
 - `event.getResourceManager(PackType)` returns a `ResourceManager` that can be used by providers to check for already existing files.
 - `event.getLookupProvider()` returns a `CompletableFuture<HolderLookup.Provider>` that is mainly used by tags and datagen registries to reference other, potentially not yet existing elements.
-- `event.includeClient()`, `event.includeServer()`, `event.includeDev()` and `event.includeReports()` are `boolean` methods that allow you to check whether specific command line arguments (see below) are enabled.
+- `event.includeDev()` and `event.includeReports()` are `boolean` methods that allow you to check whether specific command line arguments (see below) are enabled.
 
 ### Command Line Arguments
 
@@ -155,8 +164,6 @@ The data generator can accept several command line arguments:
 - `--existing path/to/folder`: Tells the data generator to consider the given folder when checking for existing files. Like with the output, it is recommended to use Gradle's `file(...).getAbsolutePath()`.
 - `--existing-mod examplemod`: Tells the data generator to consider the resources in the given mod's JAR file when checking for existing files.
 - Generator modes (all of these are boolean arguments and do not need any additional arguments):
-    - `--includeClient`: Whether to generate client resources (assets). Check at runtime with `GatherDataEvent#includeClient()`.
-    - `--includeServer`: Whether to generate server resources (data). Check at runtime with `GatherDataEvent#includeServer()`.
     - `--includeDev`: Whether to run dev tools. Generally shouldn't be used by mods. Check at runtime with `GatherDataEvent#includeDev()`.
     - `--includeReports`: Whether to dump a list of registered objects. Check at runtime with `GatherDataEvent#includeReports()`.
     - `--all`: Enable all generator modes.
@@ -167,7 +174,7 @@ All arguments can be added to the run configurations by adding the following to 
 runs {
     // other run configurations here
 
-    data {
+    clientData {
         programArguments.addAll '--arg1', 'value1', '--arg2', 'value2', '--all' // boolean args have no value
     }
 }
@@ -179,11 +186,10 @@ For example, to replicate the default arguments, you could specify the following
 runs {
     // other run configurations here
 
-    data {
+    clientData {
         programArguments.addAll '--mod', 'examplemod', // insert your own mod id
                 '--output', file('src/generated/resources').getAbsolutePath(),
-                '--includeClient',
-                '--includeServer'
+                '--all'
     }
 }
 ```
@@ -221,6 +227,7 @@ runs {
 [packmcmetaresourcepack]: https://minecraft.wiki/w/Resource_pack#Contents
 [particleprovider]: client/particles.md#datagen
 [particles]: client/particles.md
+[physicalside]: ../concepts/sides.md#the-physical-side
 [predicate]: https://minecraft.wiki/w/Predicate
 [recipeprovider]: server/recipes/index.md#data-generation
 [recipes]: server/recipes/index.md

--- a/docs/resources/server/advancements.md
+++ b/docs/resources/server/advancements.md
@@ -154,23 +154,18 @@ public void performExampleAction(ServerPlayer player, additionalContextParameter
 
 Advancements can be [datagenned][datagen] using an `AdvancementProvider`. An `AdvancementProvider` accepts a list of `AdavancementSubProviders`s, which actually generate the advancements using `Advancement.Builder`.
 
-To start, create an instance of `AdvancementProvider` within `GatherDataEvent`:
+To start, create an instance of `AdvancementProvider` within one of the `GatherDataEvent`s:
 
 ```java
 @SubscribeEvent
-public static void gatherData(GatherDataEvent event) {
-    DataGenerator generator = event.getGenerator();
-    PackOutput output = generator.getPackOutput();
-    CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
+public static void gatherData(GatherDataEvent.Client event) {
+    // Call event.createDatapackRegistryObjects(...) first if adding datapack objects
 
-    generator.addProvider(
-            event.includeServer(),
-            new AdvancementProvider(
-                output, lookupProvider,
-                // Add generators here
-                List.of(...)
-            )
-    );
+    event.createProvider((output, lookupProvider) -> new AdvancementProvider(
+        output, lookupProvider,
+        // Add generators here
+        List.of(...)
+    ));
 
      // Other providers
 }
@@ -197,20 +192,17 @@ public class ExampleClass {
     }
 }
 
-// In GatherDataEvent
-generator.addProvider(
-    event.includeServer(),
-    new AdvancementProvider(
-        output, lookupProvider,
-        // Add generators here
-        List.of(
-            // Add an instance of our generator to the list parameter. This can be done as many times as you want.
-            // Having multiple generators is purely for organization, all functionality can be achieved with a single generator.
-            new MyAdvancementGenerator(),
-            ExampleClass::generateExampleAdvancements
-        )
+// In one of the `GatherDataEvent`s
+event.createProvider((output, lookupProvider) -> new AdvancementProvider(
+    output, lookupProvider,
+    // Add generators here
+    List.of(
+        // Add an instance of our generator to the list parameter. This can be done as many times as you want.
+        // Having multiple generators is purely for organization, all functionality can be achieved with a single generator.
+        new MyAdvancementGenerator(),
+        ExampleClass::generateExampleAdvancements
     )
-);
+));
 ```
 
 To generate an advancement, you want to use an `Advancement.Builder`:

--- a/docs/resources/server/damagetypes.md
+++ b/docs/resources/server/damagetypes.md
@@ -95,32 +95,29 @@ Other damage type-specific behavior, such as invulnerability checks, is often ru
 
 _For more info, see [Data Generation for Datapack Registries][drdatagen]._
 
-Damage type JSON files can be [datagenned][datagen]. Since damage types are a datapack registry, we add a `DatapackBuiltinEntriesProvider` to the `GatherDataEvent` and put our damage types in the `RegistrySetBuilder`:
+Damage type JSON files can be [datagenned][datagen]. Since damage types are a datapack registry, we add a `DatapackBuiltinEntriesProvider` via `GatherDataEvent#createDatapackRegistryObjects` and put our damage types in the `RegistrySetBuilder`:
 
 ```java
 // In your datagen class
 @SubscribeEvent
-public static void onGatherData(GatherDataEvent event) {
-    CompletableFuture<HolderLookup.Provider> lookupProvider = event.getGenerator().addProvider(
-            event.includeServer(),
-            output -> new DatapackBuiltinEntriesProvider(output, event.getLookupProvider(), new RegistrySetBuilder()
-                    // Add a datapack builtin entry provider for damage types. If this lambda becomes longer,
-                    // this should probably be extracted into a separate method for the sake of readability.
-                    .add(Registries.DAMAGE_TYPE, bootstrap -> {
-                        // Use new DamageType() to create an in-code representation of a damage type.
-                        // The parameters map to the values of the JSON file, in the order seen above.
-                        // All parameters except for the message id and the exhaustion value are optional.
-                        bootstrap.register(EXAMPLE_DAMAGE, new DamageType(EXAMPLE_DAMAGE.location(),
-                                DamageScaling.WHEN_CAUSED_BY_LIVING_NON_PLAYER,
-                                0.1f,
-                                DamageEffects.HURT,
-                                DeathMessageType.DEFAULT))
-                    })
-                    // Add datapack providers for other datapack entries, if applicable.
-                    .add(...),
-                    Set.of(ExampleMod.MOD_ID)
+public static void onGatherData(GatherDataEvent.Client event) {
+    event.createDatapackRegistryObjects(new RegistrySetBuilder()
+        // Add a datapack builtin entry provider for damage types. If this lambda becomes longer,
+        // this should probably be extracted into a separate method for the sake of readability.
+        .add(Registries.DAMAGE_TYPE, bootstrap -> {
+            // Use new DamageType() to create an in-code representation of a damage type.
+            // The parameters map to the values of the JSON file, in the order seen above.
+            // All parameters except for the message id and the exhaustion value are optional.
+            bootstrap.register(EXAMPLE_DAMAGE, new DamageType(EXAMPLE_DAMAGE.location(),
+                DamageScaling.WHEN_CAUSED_BY_LIVING_NON_PLAYER,
+                0.1f,
+                DamageEffects.HURT,
+                DeathMessageType.DEFAULT)
             )
-    ).getRegistryProvider();
+        })
+        // Add datapack providers for other datapack entries, if applicable.
+        .add(...)
+    );
 
     // ...
 }

--- a/docs/resources/server/datamaps/index.md
+++ b/docs/resources/server/datamaps/index.md
@@ -365,16 +365,10 @@ Like all data providers, don't forget to add the provider to the event:
 
 ```java
 @SubscribeEvent
-public static void gatherData(GatherDataEvent event) {
-    DataGenerator generator = event.getGenerator();
-    PackOutput output = generator.getPackOutput();
-    CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
+public static void gatherData(GatherDataEvent.Client event) {
+    // Call event.createDatapackRegistryObjects(...) first if adding datapack objects
 
-    // other providers here
-    generator.addProvider(
-            event.includeServer(),
-            new MyDataMapProvider(output, lookupProvider)
-    );
+    event.createProvider(MyDataMapProvider::new);
 }
 ```
 

--- a/docs/resources/server/enchantments/index.md
+++ b/docs/resources/server/enchantments/index.md
@@ -206,7 +206,7 @@ The parameters to `ConditionalEffect.codec` are the codec for the generic `Condi
 
 ## Enchantment Data Generation
 
-Enchantment JSON files can be created automatically using the [data generation] system by passing a `RegistrySetBuilder` into `DatapackBuiltInEntriesProvider`. The JSON will be placed in `<project root>/src/generated/data/<modid>/enchantment/<path>.json`.
+Enchantment JSON files can be created automatically using the [data generation] system by passing a `RegistrySetBuilder` into `DatapackBuiltInEntriesProvider` via `GatherDataEvent#createDatapackRegistryObjects`. The JSON will be placed in `<project root>/src/generated/data/<modid>/enchantment/<path>.json`.
 
 For more information on how `RegistrySetBuilder` and `DatapackBuiltinEntriesProvider` work, please see the article on [Data Generation for Datapack Registries]. 
 
@@ -215,7 +215,7 @@ For more information on how `RegistrySetBuilder` and `DatapackBuiltinEntriesProv
 
 ```java
 
-// This RegistrySetBuilder should be passed into a DatapackBuiltinEntriesProvider in your GatherDataEvent handler.
+// This RegistrySetBuilder should be passed into a DatapackBuiltinEntriesProvider in your `GatherDataEvent`s listener.
 RegistrySetBuilder BUILDER = new RegistrySetBuilder();
 BUILDER.add(
     Registries.ENCHANTMENT,

--- a/docs/resources/server/loottables/glm.md
+++ b/docs/resources/server/loottables/glm.md
@@ -149,7 +149,7 @@ GLMs can be [datagenned][datagen]. This is done by subclassing `GlobalLootModifi
 
 ```java
 public class MyGlobalLootModifierProvider extends GlobalLootModifierProvider {
-    // Get the PackOutput from GatherDataEvent.
+    // Get the parameters from the `GatherDataEvent`s.
     public MyGlobalLootModifierProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
         super(output, registries, ExampleMod.MOD_ID);
     }
@@ -173,15 +173,14 @@ public class MyGlobalLootModifierProvider extends GlobalLootModifierProvider {
 }
 ```
 
-And like all data providers, you must register the provider to `GatherDataEvent`:
+And like all data providers, you must register the provider to the `GatherDataEvent`s:
 
 ```java
 @SubscribeEvent
-public static void onGatherData(GatherDataEvent event) {
-    event.getGenerator().addProvider(
-        event.includeServer(),
-        output -> new MyGlobalLootModifierProvider(output, event.getLookupProvider())
-    );
+public static void onGatherData(GatherDataEvent.Client event) {
+    // Call event.createDatapackRegistryObjects(...) first if adding datapack objects
+
+    event.createProvider(MyGlobalLootModifierProvider::new);
 }
 ```
 

--- a/docs/resources/server/loottables/index.md
+++ b/docs/resources/server/loottables/index.md
@@ -257,21 +257,20 @@ Loot tables can be [datagenned][datagen] by registering a `LootTableProvider` an
 
 ```java
 @SubscribeEvent
-public static void onGatherData(GatherDataEvent event) {
-    event.getGenerator().addProvider(
-            event.includeServer(),
-            output -> new LootTableProvider(
-                    output,
-                    // A set of required table resource locations. These are later verified to be present.
-                    // It is generally not recommended for mods to validate existence,
-                    // therefore we pass in an empty set.
-                    Set.of(),
-                    // A list of sub provider entries. See below for what values to use here.
-                    List.of(...),
-                    // The registry access
-                    event.getLookupProvider()
-            )
-    );
+public static void onGatherData(GatherDataEvent.Client event) {
+    // Call event.createDatapackRegistryObjects(...) first if adding datapack objects
+
+    event.createProvider((output, lookupProvider) -> new LootTableProvider(
+        output,
+        // A set of required table resource locations. These are later verified to be present.
+        // It is generally not recommended for mods to validate existence,
+        // therefore we pass in an empty set.
+        Set.of(),
+        // A list of sub provider entries. See below for what values to use here.
+        List.of(...),
+        // The registry access
+        lookupProvider
+    ));
 }
 ```
 

--- a/docs/resources/server/recipes/index.md
+++ b/docs/resources/server/recipes/index.md
@@ -167,7 +167,7 @@ public class MyRecipeProvider extends RecipeProvider {
 
     // The runner to add to the data generator
     public static class Runner extends RecipeProvider.Runner {
-        // Get the parameters from GatherDataEvent.
+        // Get the parameters from the `GatherDataEvent`s.
         public Runner(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider) {
             super(output, lookupProvider);
         }
@@ -184,20 +184,14 @@ Of note is the `RecipeOutput` parameter. Minecraft uses this object to automatic
 
 Recipes themselves are commonly added through subclasses of `RecipeBuilder`. Listing all vanilla recipe builders is beyond the scope of this article (they are explained in the [Built-In Recipe Types article][builtin]), however creating your own builder is explained [in the custom recipes page][customdatagen].
 
-Like all other data providers, recipe providers must be registered to `GatherDataEvent` like so:
+Like all other data providers, recipe providers must be registered to the `GatherDataEvent`s like so:
 
 ```java
 @SubscribeEvent
-public static void gatherData(GatherDataEvent event) {
-    DataGenerator generator = event.getGenerator();
-    PackOutput output = generator.getPackOutput();
-    CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
+public static void gatherData(GatherDataEvent.Client event) {
+    // Call event.createDatapackRegistryObjects(...) first if adding datapack objects
 
-    // other providers here
-    generator.addProvider(
-            event.includeServer(),
-            new MyRecipeProvider.Runner(output, lookupProvider)
-    );
+    event.createProvider(MyRecipeProvider.Runner::new);
 }
 ```
 

--- a/docs/resources/server/tags.md
+++ b/docs/resources/server/tags.md
@@ -145,7 +145,7 @@ For the sake of example, let's assume that we want to generate block tags. (All 
 
 ```java
 public class MyBlockTagsProvider extends BlockTagsProvider {
-    // Get parameters from GatherDataEvent.
+    // Get parameters from one of the `GatherDataEvent`s.
     public MyBlockTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider) {
         super(output, lookupProvider, ExampleMod.MOD_ID);
     }
@@ -217,19 +217,14 @@ This example results in the following tag JSON:
 }
 ```
 
-Like all data providers, add each tag provider to the `GatherDataEvent`:
+Like all data providers, add each tag provider to the `GatherDataEvent`s:
 
 ```java
 @SubscribeEvent
-public static void gatherData(GatherDataEvent event) {
-    PackOutput output = event.getGenerator().getPackOutput();
-    CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
+public static void gatherData(GatherDataEvent.Client event) {
+    // Call event.createDatapackRegistryObjects(...) first if adding datapack objects
 
-    // other providers here
-    event.getGenerator().addProvider(
-        event.includeServer(),
-        new MyBlockTagsProvider(output, lookupProvider)
-    );
+    event.createProvider(MyBlockTagsProvider::new);
 }
 ```
 
@@ -246,7 +241,7 @@ To create a custom tag provider for a custom [registry], or for a vanilla or Neo
 
 ```java
 public class MyRecipeTypeTagsProvider extends TagsProvider<RecipeType<?>> {
-    // Get parameters from GatherDataEvent.
+    // Get parameters from the `GatherDataEvent`s.
     public MyRecipeTypeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider) {
         // Second parameter is the registry key we are generating the tags for.
         super(output, Registries.RECIPE_TYPE, lookupProvider, ExampleMod.MOD_ID);
@@ -261,7 +256,7 @@ If desirable and applicable, you can also extend `IntrinsicHolderTagsProvider<T>
 
 ```java
 public class MyAttributeTagsProvider extends IntrinsicHolderTagsProvider<Attribute> {
-    // Get parameters from GatherDataEvent.
+    // Get parameters from the `GatherDataEvent`s.
     public MyAttributeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider) {
         super(output,
             Registries.ATTRIBUTE,

--- a/docs/worldgen/biomemodifier.md
+++ b/docs/worldgen/biomemodifier.md
@@ -60,7 +60,7 @@ public static final ResourceKey<BiomeModifier> NO_OP_EXAMPLE = ResourceKey.creat
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Register the biome modifiers.
     bootstrap.register(NO_OP_EXAMPLE, NoneBiomeModifier.INSTANCE);
@@ -106,7 +106,7 @@ public static final ResourceKey<BiomeModifier> ADD_FEATURES_EXAMPLE = ResourceKe
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.
@@ -174,7 +174,7 @@ public static final ResourceKey<BiomeModifier> REMOVE_FEATURES_EXAMPLE = Resourc
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.
@@ -250,7 +250,7 @@ public static final ResourceKey<BiomeModifier> ADD_SPAWNS_EXAMPLE = ResourceKey.
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.
@@ -307,7 +307,7 @@ public static final ResourceKey<BiomeModifier> REMOVE_SPAWNS_EXAMPLE = ResourceK
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.
@@ -374,7 +374,7 @@ public static final ResourceKey<BiomeModifier> ADD_SPAWN_COSTS_EXAMPLE = Resourc
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.
@@ -433,7 +433,7 @@ public static final ResourceKey<BiomeModifier> REMOVE_SPAWN_COSTS_EXAMPLE = Reso
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.
@@ -489,7 +489,7 @@ public static final ResourceKey<BiomeModifier> ADD_CARVERS_EXAMPLE = ResourceKey
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.
@@ -543,7 +543,7 @@ public static final ResourceKey<BiomeModifier> REMOVE_CARVERS_EXAMPLE = Resource
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.
@@ -650,7 +650,7 @@ public static final ResourceKey<BiomeModifier> EXAMPLE_MODIFIER = ResourceKey.cr
 );
 
 // BUILDER is a RegistrySetBuilder passed to DatapackBuiltinEntriesProvider
-// in a listener for GatherDataEvent.
+// in a listener for the `GatherDataEvent`s.
 BUILDER.add(NeoForgeRegistries.Keys.BIOME_MODIFIERS, bootstrap -> {
     // Lookup any necessary registries.
     // Static registries only need to be looked up if you need to grab the tag data.


### PR DESCRIPTION
Updates the usage of the `GatherDataEvent` to its current implementation in 1.21.4. Also switches all examples to use one of the available `create*` methods as required.

------------------
Preview URL: https://pr-223.neoforged-docs-previews.pages.dev