### PR TITLE
Update Github actions to v4

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build and upload site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm


### PR DESCRIPTION
v3 of some of the Github Actions have been disabled since January 30th, 2025. This updates the actions to their v4 counterparts, allowing PR building and preview deployment to function.

------------------
Preview URL: https://pr-224.neoforged-docs-previews.pages.dev