### PR TITLE
Add support for syntax highlighting of '.properties' files

### DIFF
--- a/docs/gettingstarted/modfiles.md
+++ b/docs/gettingstarted/modfiles.md
@@ -45,8 +45,8 @@ While the `group` property in the `build.gradle` is only necessary if you plan t
 
 The group id should be set to your top-level package. See [Packaging][packaging] for more information.
 
-```text
-// In your gradle.properties file
+```properties
+# In your gradle.properties file
 mod_group_id=com.example
 ```
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -190,7 +190,7 @@ const config = {
       prism: {
         theme: lightTheme,
         darkTheme: darkTheme,
-        additionalLanguages: ["java", "gradle", "toml", "groovy", "kotlin", "javascript", "json", "json5"],
+        additionalLanguages: ["java", "gradle", "toml", "groovy", "kotlin", "javascript", "json", "json5", "properties"],
       },
       algolia: {
         // The application ID provided by Algolia

--- a/versioned_docs/version-1.20.4/gettingstarted/modfiles.md
+++ b/versioned_docs/version-1.20.4/gettingstarted/modfiles.md
@@ -33,8 +33,8 @@ While the `group` property in the `build.gradle` is only necessary if you plan t
 
 The group id should be set to your top-level package. See [Packaging][packaging] for more information.
 
-```text
-// In your gradle.properties file
+```properties
+# In your gradle.properties file
 mod_group_id=com.example
 ```
 

--- a/versioned_docs/version-1.20.6/gettingstarted/modfiles.md
+++ b/versioned_docs/version-1.20.6/gettingstarted/modfiles.md
@@ -42,8 +42,8 @@ While the `group` property in the `build.gradle` is only necessary if you plan t
 
 The group id should be set to your top-level package. See [Packaging][packaging] for more information.
 
-```text
-// In your gradle.properties file
+```properties
+# In your gradle.properties file
 mod_group_id=com.example
 ```
 

--- a/versioned_docs/version-1.21.1/gettingstarted/modfiles.md
+++ b/versioned_docs/version-1.21.1/gettingstarted/modfiles.md
@@ -42,8 +42,8 @@ While the `group` property in the `build.gradle` is only necessary if you plan t
 
 The group id should be set to your top-level package. See [Packaging][packaging] for more information.
 
-```text
-// In your gradle.properties file
+```properties
+# In your gradle.properties file
 mod_group_id=com.example
 ```
 

--- a/versioned_docs/version-1.21.3/gettingstarted/modfiles.md
+++ b/versioned_docs/version-1.21.3/gettingstarted/modfiles.md
@@ -42,8 +42,8 @@ While the `group` property in the `build.gradle` is only necessary if you plan t
 
 The group id should be set to your top-level package. See [Packaging][packaging] for more information.
 
-```text
-// In your gradle.properties file
+```properties
+# In your gradle.properties file
 mod_group_id=com.example
 ```
 


### PR DESCRIPTION
At the moment, only the [Parchment site](https://docs.neoforged.net/neogradle/docs/parchment) uses a `properties` area, but maybe there will be more in the future.

Before: https://docs.neoforged.net/neogradle/docs/parchment

After: https://pr-233.neoforged-docs-previews.pages.dev/neogradle/docs/parchment

------------------
Preview URL: https://pr-233.neoforged-docs-previews.pages.dev