### PR TITLE
Give more precisions on how to register a screen with a menu

### DIFF
--- a/docs/gui/screens.md
+++ b/docs/gui/screens.md
@@ -408,11 +408,12 @@ When rendering the label, you do **not** need to specify the `leftPos` and `topP
 
 ## Registering an AbstractContainerScreen
 
-To use an `AbstractContainerScreen` with a menu, it needs to be registered. This can be done by calling `register` within the `RegisterMenuScreensEvent` on the [**mod event bus**][modbus].
+To use an `AbstractContainerScreen` with a menu, it needs to be registered. This can be done by calling `register` within the `RegisterMenuScreensEvent` on the [**mod event bus**][modbus], for example in the `ClientModEvents` class.
 
 ```java
 // Event is listened to on the mod event bus
-private void registerScreens(RegisterMenuScreensEvent event) {
+@SubscribeEvent
+public static void registerScreens(RegisterMenuScreensEvent event) {
     event.register(MY_MENU.get(), MyContainerScreen::new);
 }
 ```


### PR DESCRIPTION
# Description

Reading the documentation about how to register a screen with a menu was a little bit confusing for me, since the `registerScreens` is declared private and non-static.

It seems the usual way to declare this method is in the mod's `ClientModEvents` class as a `public static` method with `@SubscribeEvent`. To show these elements in the documentation can help people to quickly understand how to do.

# Changes made

I updated the "Registering an AbstractContainerScreen" section to make it less confusing.