### PR TITLE
Clarify dangers of AT usage with private methods

### DIFF
--- a/docs/advanced/accesstransformers.md
+++ b/docs/advanced/accesstransformers.md
@@ -103,7 +103,7 @@ A special modifier `+f` and `-f` can be appended to the aforementioned modifiers
 :::danger
 Directives only modify the method they directly reference; any overriding methods will not be access-transformed. It is advised to ensure transformed methods do not have non-transformed overrides that restrict the visibility, which will result in the JVM throwing an error.
 
-Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
+Examples of methods that can be safely transformed are `final` methods (or methods in `final` classes), and `static` methods. `private` methods are generally safe as well; however, they could cause unintentional overrides in any subtypes, so some additional manual validation should be performed.
 :::
 
 ### Targets and Directives

--- a/versioned_docs/version-1.20.4/advanced/accesstransformers.mdx
+++ b/versioned_docs/version-1.20.4/advanced/accesstransformers.mdx
@@ -91,7 +91,7 @@ A special modifier `+f` and `-f` can be appended to the aforementioned modifiers
 :::danger
 Directives only modify the method they directly reference; any overriding methods will not be access-transformed. It is advised to ensure transformed methods do not have non-transformed overrides that restrict the visibility, which will result in the JVM throwing an error.
 
-Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
+Examples of methods that can be safely transformed are `final` methods (or methods in `final` classes), and `static` methods. `private` methods are generally safe as well; however, they could cause unintentional overrides in any subtypes, so some additional manual validation should be performed.
 :::
 
 ## Targets and Directives

--- a/versioned_docs/version-1.20.6/advanced/accesstransformers.md
+++ b/versioned_docs/version-1.20.6/advanced/accesstransformers.md
@@ -73,7 +73,7 @@ A special modifier `+f` and `-f` can be appended to the aforementioned modifiers
 :::danger
 Directives only modify the method they directly reference; any overriding methods will not be access-transformed. It is advised to ensure transformed methods do not have non-transformed overrides that restrict the visibility, which will result in the JVM throwing an error.
 
-Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
+Examples of methods that can be safely transformed are `final` methods (or methods in `final` classes), and `static` methods. `private` methods are generally safe as well; however, they could cause unintentional overrides in any subtypes, so some additional manual validation should be performed.
 :::
 
 ### Targets and Directives

--- a/versioned_docs/version-1.21.1/advanced/accesstransformers.md
+++ b/versioned_docs/version-1.21.1/advanced/accesstransformers.md
@@ -73,7 +73,7 @@ A special modifier `+f` and `-f` can be appended to the aforementioned modifiers
 :::danger
 Directives only modify the method they directly reference; any overriding methods will not be access-transformed. It is advised to ensure transformed methods do not have non-transformed overrides that restrict the visibility, which will result in the JVM throwing an error.
 
-Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
+Examples of methods that can be safely transformed are `final` methods (or methods in `final` classes), and `static` methods. `private` methods are generally safe as well; however, they could cause unintentional overrides in any subtypes, so some additional manual validation should be performed.
 :::
 
 ### Targets and Directives

--- a/versioned_docs/version-1.21.3/advanced/accesstransformers.md
+++ b/versioned_docs/version-1.21.3/advanced/accesstransformers.md
@@ -73,7 +73,7 @@ A special modifier `+f` and `-f` can be appended to the aforementioned modifiers
 :::danger
 Directives only modify the method they directly reference; any overriding methods will not be access-transformed. It is advised to ensure transformed methods do not have non-transformed overrides that restrict the visibility, which will result in the JVM throwing an error.
 
-Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
+Examples of methods that can be safely transformed are `final` methods (or methods in `final` classes), and `static` methods. `private` methods are generally safe as well; however, they could cause unintentional overrides in any subtypes, so some additional manual validation should be performed.
 :::
 
 ### Targets and Directives

--- a/versioned_docs/version-1.21.4/advanced/accesstransformers.md
+++ b/versioned_docs/version-1.21.4/advanced/accesstransformers.md
@@ -73,7 +73,7 @@ A special modifier `+f` and `-f` can be appended to the aforementioned modifiers
 :::danger
 Directives only modify the method they directly reference; any overriding methods will not be access-transformed. It is advised to ensure transformed methods do not have non-transformed overrides that restrict the visibility, which will result in the JVM throwing an error.
 
-Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
+Examples of methods that can be safely transformed are `final` methods (or methods in `final` classes), and `static` methods. `private` methods are generally safe as well; however, they could cause unintentional overrides in any subtypes, so some additional manual validation should be performed.
 :::
 
 ### Targets and Directives

--- a/versioned_docs/version-1.21.5/advanced/accesstransformers.md
+++ b/versioned_docs/version-1.21.5/advanced/accesstransformers.md
@@ -73,7 +73,7 @@ A special modifier `+f` and `-f` can be appended to the aforementioned modifiers
 :::danger
 Directives only modify the method they directly reference; any overriding methods will not be access-transformed. It is advised to ensure transformed methods do not have non-transformed overrides that restrict the visibility, which will result in the JVM throwing an error.
 
-Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
+Examples of methods that can be safely transformed are `final` methods (or methods in `final` classes), and `static` methods. `private` methods are generally safe as well; however, they could cause unintentional overrides in any subtypes, so some additional manual validation should be performed.
 :::
 
 ### Targets and Directives


### PR DESCRIPTION
Closes #266 

Adds some additional information about `private` methods due to a potential override that may occur with the subimplementatoin.