### PR TITLE
Correct the keys stated to be used in the oxidized data map

### DIFF
--- a/versioned_docs/version-1.21.1/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.1/resources/server/datamaps/builtin.md
@@ -107,7 +107,7 @@ Allows configuring oxidation stages, as a replacement for `WeatheringCopper#NEXT
 ```json5
 {
     // The block this block will turn into once oxidized
-    "next_oxidized_stage": "examplemod:oxidized_block"
+    "next_oxidation_stage": "examplemod:oxidized_block"
 }
 ```
 
@@ -122,7 +122,7 @@ Example:
     "values": {
         "mymod:custom_copper": {
             // Make a custom copper block oxidize into custom oxidized copper
-            "next_oxidized_stage": "mymod:custom_oxidized_copper"
+            "next_oxidation_stage": "mymod:custom_oxidized_copper"
         }
     }
 }

--- a/versioned_docs/version-1.21.3/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.3/resources/server/datamaps/builtin.md
@@ -107,7 +107,7 @@ Allows configuring oxidation stages, as a replacement for `WeatheringCopper#NEXT
 ```json5
 {
     // The block this block will turn into once oxidized
-    "next_oxidized_stage": "examplemod:oxidized_block"
+    "next_oxidation_stage": "examplemod:oxidized_block"
 }
 ```
 
@@ -122,7 +122,7 @@ Example:
     "values": {
         "mymod:custom_copper": {
             // Make a custom copper block oxidize into custom oxidized copper
-            "next_oxidized_stage": "mymod:custom_oxidized_copper"
+            "next_oxidation_stage": "mymod:custom_oxidized_copper"
         }
     }
 }

--- a/versioned_docs/version-1.21.4/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.4/resources/server/datamaps/builtin.md
@@ -107,7 +107,7 @@ Allows configuring oxidation stages, as a replacement for `WeatheringCopper#NEXT
 ```json5
 {
     // The block this block will turn into once oxidized
-    "next_oxidized_stage": "examplemod:oxidized_block"
+    "next_oxidation_stage": "examplemod:oxidized_block"
 }
 ```
 
@@ -122,7 +122,7 @@ Example:
     "values": {
         "mymod:custom_copper": {
             // Make a custom copper block oxidize into custom oxidized copper
-            "next_oxidized_stage": "mymod:custom_oxidized_copper"
+            "next_oxidation_stage": "mymod:custom_oxidized_copper"
         }
     }
 }

--- a/versioned_docs/version-1.21.5/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.5/resources/server/datamaps/builtin.md
@@ -107,7 +107,7 @@ Allows configuring oxidation stages, as a replacement for `WeatheringCopper#NEXT
 ```json5
 {
     // The block this block will turn into once oxidized
-    "next_oxidized_stage": "examplemod:oxidized_block"
+    "next_oxidation_stage": "examplemod:oxidized_block"
 }
 ```
 
@@ -122,7 +122,7 @@ Example:
     "values": {
         "mymod:custom_copper": {
             // Make a custom copper block oxidize into custom oxidized copper
-            "next_oxidized_stage": "mymod:custom_oxidized_copper"
+            "next_oxidation_stage": "mymod:custom_oxidized_copper"
         }
     }
 }


### PR DESCRIPTION
In 1.21.1, the correct key for entries in the oxidizables data map is `next_oxidation_stage`, not `next_oxidized_stage` (source: https://github.com/neoforged/NeoForge/blob/1.21.x/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/Oxidizable.java#L24C68-L24C88)

------------------
Preview URL: https://pr-283.neoforged-docs-previews.pages.dev