### PR TITLE
Fix category links shifting content on hover

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -66,11 +66,12 @@ a.no-underline {
 
 .link-card:hover {
   transform: scale(1.05);
-  border: 1px solid var(--ifm-color-primary-light);
+  border-color: var(--ifm-color-primary-light);
 }
 
 .link-card {
   transition: transform 450ms ease-in-out;
+  border: 1px solid transparent;
 }
 
 h2 {


### PR DESCRIPTION
Making border width change conditionally shifts the contents of a website around. This fixes it for the categories on the root page by making the border width constant and only animating the border color.