### PR TITLE
Add new Inventories & Transfers category and move some articles around

### DIFF
--- a/docs/blockentities/index.md
+++ b/docs/blockentities/index.md
@@ -267,7 +267,7 @@ It is important that you do safety checks, as the `BlockEntity` might already be
 [block]: ../blocks/index.md
 [blockreg]: ../blocks/index.md#basic-blocks
 [blockstate]: ../blocks/states.md
-[container]: container.md
+[container]: ../inventories/container.md
 [dataattachments]: ../datastorage/attachments.md
 [entities]: ../entities/index.md
 [modbus]: ../concepts/events.md#event-buses

--- a/docs/datastorage/_category_.json
+++ b/docs/datastorage/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Data Storage",
-    "position": 8
+    "position": 9
 }

--- a/docs/entities/attributes.md
+++ b/docs/entities/attributes.md
@@ -249,7 +249,7 @@ The same rules also apply for any other `Attribute` subclass, i.e., we generally
 :::
 
 [custom]: #custom-attributes
-[equipment]: ../blockentities/container.md#containers-on-entitys
+[equipment]: ../inventories/container.md#containers-on-entitys
 [event]: ../concepts/events.md
 [livingentity]: livingentity.md
 [loottables]: ../resources/server/loottables/index.md

--- a/docs/entities/livingentity.md
+++ b/docs/entities/livingentity.md
@@ -258,7 +258,7 @@ If all those checks pass, a spawn entry is chosen from the above list based on t
 [addspawns]: ../worldgen/biomemodifier.md#add-spawns
 [attributes]: attributes.md
 [clientitem]: ../resources/client/models/items.md
-[containers]: ../blockentities/container.md
+[containers]: ../inventories/container.md
 [creative]: ../items/index.md#creative-tabs
 [damage]: index.md#damaging-entities
 [damagesources]: ../resources/server/damagetypes.md#creating-and-using-damage-sources

--- a/docs/gui/_category_.json
+++ b/docs/gui/_category_.json
@@ -1,4 +1,0 @@
-{
-    "label": "GUIs",
-    "position": 9
-}

--- a/docs/inventories/_category_.json
+++ b/docs/inventories/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Inventories & Transfers",
+    "position": 8
+}

--- a/docs/inventories/capabilities.md
+++ b/docs/inventories/capabilities.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 1
 ---
 # Capabilities
 

--- a/docs/inventories/container.md
+++ b/docs/inventories/container.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 0
+---
 # Containers
 
 A popular use case of [block entities][blockentity] is to store items of some kind. Some of the most essential [blocks][block] in Minecraft, such as the furnace or the chest, use block entities for this purpose. To store items on something, Minecraft uses `Container`s.
@@ -312,12 +315,12 @@ The inventory contents are stored in two places:
 
 When iterating over the inventory contents, it is recommended to iterate over `items`, then over `equipment` using `Inventory#EQUIPMENT_SLOT_MAPPING` for the indices.
 
-[beremove]: index.md#removing-block-entities
+[beremove]: ../blockentities/index.md#removing-block-entities
 [block]: ../blocks/index.md
-[blockentity]: index.md
+[blockentity]: ../blockentities/index.md
 [component]: ../resources/client/i18n.md#components
 [datacomponent]: ../items/datacomponents.md
 [entity]: ../entities/index.md
 [item]: ../items/index.md
 [itemstack]: ../items/index.md#itemstacks
-[menu]: ../gui/menus.md
+[menu]: menus.md

--- a/docs/inventories/menus.md
+++ b/docs/inventories/menus.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 2
+---
 # Menus
 
 Menus are one type of backend for Graphical User Interfaces, or GUIs; they handle the logic involved in interacting with some represented data holder. Menus themselves are not data holders. They are views which allow to user to indirectly modify the internal data holder state. As such, a data holder should not be directly coupled to any menu, instead passing in the data references to invoke and modify.
@@ -410,8 +413,8 @@ Once again, this is the simplest way to implement the logic, not the only way.
 [acm]: #abstractcontainermenu
 [mt]: #menutype
 [qms]: #quickmovestack
-[cap]: ../datastorage/capabilities.md#neoforge-provided-capabilities
-[screen]: screens.md
+[cap]: capabilities.md#neoforge-provided-capabilities
+[screen]: ../rendering/screens.md
 [icf]: #icontainerfactory
 [side]: ../concepts/sides.md#the-logical-side
 [interaction]: ../items/interactions.md#right-clicking-an-item

--- a/docs/rendering/feature.md
+++ b/docs/rendering/feature.md
@@ -68,5 +68,5 @@ Once the features have finished rendering, the `SubmitNodeStorage` is cleared fo
 
 [blockentities]: ../blockentities/ber.md#blockentityrenderer
 [entities]: ../entities/renderer.md#entity-renderers
-[gui]: ../gui/screens.md#picture-in-picture
+[gui]: screens.md#picture-in-picture
 [particles]: #TODO

--- a/docs/rendering/screens.md
+++ b/docs/rendering/screens.md
@@ -744,7 +744,7 @@ public static void registerScreens(RegisterMenuScreensEvent event) {
 }
 ```
 
-[menus]: menus.md
+[menus]: ../inventories/menus.md
 [network]: ../networking/index.md
 [screen]: #the-screen-subtype
 [argb]: https://en.wikipedia.org/wiki/RGBA_color_model#ARGB32

--- a/docs/resources/client/models/items.md
+++ b/docs/resources/client/models/items.md
@@ -1545,11 +1545,11 @@ protected void registerModels(BlockModelGenerators blockModels, ItemModelGenerat
 
 [assets]: ../../index.md#assets
 [ber]: ../../../blockentities/ber.md
-[capability]: ../../../datastorage/capabilities.md#registering-capabilities
+[capability]: ../../../inventories/capabilities.md#registering-capabilities
 [composite]: modelloaders.md#composite-model
 [features]: ../../../rendering/feature.md
 [itemmodel]: #manually-rendering-an-item
 [modbus]: ../../../concepts/events.md#event-buses
 [models]: modelsystem.md
 [rl]: ../../../misc/resourcelocation.md
-[screens]: ../../../gui/screens.md#items
+[screens]: ../../../rendering/screens.md#items

--- a/versioned_docs/version-1.21.1/advanced/_category_.json
+++ b/versioned_docs/version-1.21.1/advanced/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Advanced Topics",
-    "position": 12
+    "position": 13
 }

--- a/versioned_docs/version-1.21.1/datastorage/_category_.json
+++ b/versioned_docs/version-1.21.1/datastorage/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Data Storage",
-    "position": 8
+    "position": 9
 }

--- a/versioned_docs/version-1.21.1/gui/_category_.json
+++ b/versioned_docs/version-1.21.1/gui/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "GUIs",
-    "position": 9
+    "position": 10
 }

--- a/versioned_docs/version-1.21.1/gui/menus.md
+++ b/versioned_docs/version-1.21.1/gui/menus.md
@@ -341,7 +341,7 @@ Once again, this is the simplest way to implement the logic, not the only way.
 [acm]: #abstractcontainermenu
 [mt]: #menutype
 [qms]: #quickmovestack
-[cap]: ../datastorage/capabilities.md#neoforge-provided-capabilities
+[cap]: ../inventories/capabilities.md#neoforge-provided-capabilities
 [screen]: ./screens.md
 [icf]: #icontainerfactory
 [side]: ../concepts/sides.md#the-logical-side

--- a/versioned_docs/version-1.21.1/inventories/_category_.json
+++ b/versioned_docs/version-1.21.1/inventories/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Inventories & Transfers",
+    "position": 8
+}

--- a/versioned_docs/version-1.21.1/inventories/capabilities.md
+++ b/versioned_docs/version-1.21.1/inventories/capabilities.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 2
 ---
 # Capabilities
 
@@ -257,7 +257,7 @@ They need to be registered in the `RegisterCapabilitiesEvent`.
 Block providers are registered with `registerBlock`. For example:
 
 ```java
-@SubscribeEvent // on the mod event bus
+@SubscribeEvent  // on the mod event bus
 public static void registerCapabilities(RegisterCapabilitiesEvent event) {
     event.registerBlock(
         Capabilities.ItemHandler.BLOCK, // capability to register for

--- a/versioned_docs/version-1.21.1/inventories/container.md
+++ b/versioned_docs/version-1.21.1/inventories/container.md
@@ -1,6 +1,9 @@
+---
+sidebar_position: 1
+---
 # Containers
 
-A popular use case of [block entities][blockentity] is to store items of some kind. Some of the most essential [blocks][block] in Minecraft, such as the furnace or the chest, use block entities for this purpose. To store items on something, Minecraft uses `Container`s.
+Many systems in Minecraft, such as [block entities][blockentity] or entities, store items of some kind. To store items on something, Minecraft uses `Container` implementations.
 
 The `Container` interface defines methods such as `#getItem`, `#setItem` and `#removeItem` that can be used to query and update the container. Since it is an interface, it does not actually contain a backing list or other data structure, that is up to the implementing system.
 
@@ -303,8 +306,7 @@ The inventory contents are stored in three `public final NonNullList<ItemStack>`
 
 When iterating over the inventory contents, it is recommended to iterate over `items`, then over `armor` and then over `offhand`, to be consistent with vanilla behavior.
 
-[block]: ../blocks/index.md
-[blockentity]: index.md
+[blockentity]: ../blockentities/index.md
 [component]: ../resources/client/i18n.md#components
 [datacomponent]: ../items/datacomponents.md
 [item]: ../items/index.md

--- a/versioned_docs/version-1.21.1/misc/_category_.json
+++ b/versioned_docs/version-1.21.1/misc/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Miscellaneous",
-    "position": 13
+    "position": 14
 }

--- a/versioned_docs/version-1.21.1/networking/_category_.json
+++ b/versioned_docs/version-1.21.1/networking/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Networking",
-    "position": 11
+    "position": 12
 }

--- a/versioned_docs/version-1.21.1/worldgen/_category_.json
+++ b/versioned_docs/version-1.21.1/worldgen/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Worldgen",
-    "position": 10
+    "position": 11
 }

--- a/versioned_docs/version-1.21.3/advanced/_category_.json
+++ b/versioned_docs/version-1.21.3/advanced/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Advanced Topics",
-    "position": 12
+    "position": 13
 }

--- a/versioned_docs/version-1.21.3/datastorage/_category_.json
+++ b/versioned_docs/version-1.21.3/datastorage/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Data Storage",
-    "position": 8
+    "position": 9
 }

--- a/versioned_docs/version-1.21.3/gui/_category_.json
+++ b/versioned_docs/version-1.21.3/gui/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "GUIs",
-    "position": 9
+    "position": 10
 }

--- a/versioned_docs/version-1.21.3/gui/menus.md
+++ b/versioned_docs/version-1.21.3/gui/menus.md
@@ -347,7 +347,7 @@ Once again, this is the simplest way to implement the logic, not the only way.
 [acm]: #abstractcontainermenu
 [mt]: #menutype
 [qms]: #quickmovestack
-[cap]: ../datastorage/capabilities.md#neoforge-provided-capabilities
+[cap]: ../inventories/capabilities.md#neoforge-provided-capabilities
 [screen]: screens.md
 [icf]: #icontainerfactory
 [side]: ../concepts/sides.md#the-logical-side

--- a/versioned_docs/version-1.21.3/inventories/_category_.json
+++ b/versioned_docs/version-1.21.3/inventories/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Inventories & Transfers",
+    "position": 8
+}

--- a/versioned_docs/version-1.21.3/inventories/capabilities.md
+++ b/versioned_docs/version-1.21.3/inventories/capabilities.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 2
 ---
 # Capabilities
 

--- a/versioned_docs/version-1.21.3/inventories/container.md
+++ b/versioned_docs/version-1.21.3/inventories/container.md
@@ -1,6 +1,9 @@
+---
+sidebar_position: 1
+---
 # Containers
 
-A popular use case of [block entities][blockentity] is to store items of some kind. Some of the most essential [blocks][block] in Minecraft, such as the furnace or the chest, use block entities for this purpose. To store items on something, Minecraft uses `Container`s.
+Many systems in Minecraft, such as [block entities][blockentity] or entities, store items of some kind. To store items on something, Minecraft uses `Container` implementations.
 
 The `Container` interface defines methods such as `#getItem`, `#setItem` and `#removeItem` that can be used to query and update the container. Since it is an interface, it does not actually contain a backing list or other data structure, that is up to the implementing system.
 
@@ -156,10 +159,6 @@ public class MyBlockEntity extends BaseContainerBlockEntity {
 
 Keep in mind that this class is a `BlockEntity` and a `Container` at the same time. This means that you can use the class as a supertype for your block entity to get a functioning block entity with a pre-implemented container.
 
-:::note
-`BlockEntity`s that implement `Container` handle dropping their contents by default. If you choose not to implement `Container`, then you will need to handle the [removal logic][beremove].
-:::
-
 ### `WorldlyContainer`
 
 `WorldlyContainer` is a sub-interface of `Container` that allows accessing slots of the given `Container` by `Direction`. It is mainly intended for block entities that only expose parts of their container to a particular side. For example, this could be used by a machine that outputs to one side and takes inputs from all other sides, or vice-versa. A simple implementation of the interface could look like this:
@@ -268,7 +267,7 @@ Be aware that menus that directly interface with `Container`s must `#copy()` the
 
 ## `Container`s on `Entity`s
 
-`Container`s on [`Entity`s][entity] are finicky: whether an entity has a container or not cannot be universally determined. It all depends on what entity you are handling, and as such can require a lot of special-casing.
+`Container`s on `Entity`s are finicky: whether an entity has a container or not cannot be universally determined. It all depends on what entity you are handling, and as such can require a lot of special-casing.
 
 If you are creating an entity yourself, there is nothing stopping you from implementing `Container` on it directly, though be aware that you will not be able to use superclasses such as `SimpleContainer` (since `Entity` is the superclass).
 
@@ -307,12 +306,9 @@ The inventory contents are stored in three `public final NonNullList<ItemStack>`
 
 When iterating over the inventory contents, it is recommended to iterate over `items`, then over `armor` and then over `offhand`, to be consistent with vanilla behavior.
 
-[beremove]: index.md#removing-block-entities
-[block]: ../blocks/index.md
-[blockentity]: index.md
+[blockentity]: ../blockentities/index.md
 [component]: ../resources/client/i18n.md#components
 [datacomponent]: ../items/datacomponents.md
-[entity]: ../entities/index.md
 [item]: ../items/index.md
 [itemstack]: ../items/index.md#itemstacks
 [menu]: ../gui/menus.md

--- a/versioned_docs/version-1.21.3/misc/_category_.json
+++ b/versioned_docs/version-1.21.3/misc/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Miscellaneous",
-    "position": 13
+    "position": 14
 }

--- a/versioned_docs/version-1.21.3/networking/_category_.json
+++ b/versioned_docs/version-1.21.3/networking/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Networking",
-    "position": 11
+    "position": 12
 }

--- a/versioned_docs/version-1.21.3/worldgen/_category_.json
+++ b/versioned_docs/version-1.21.3/worldgen/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Worldgen",
-    "position": 10
+    "position": 11
 }

--- a/versioned_docs/version-1.21.4/advanced/_category_.json
+++ b/versioned_docs/version-1.21.4/advanced/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Advanced Topics",
-    "position": 12
+    "position": 13
 }

--- a/versioned_docs/version-1.21.4/datastorage/_category_.json
+++ b/versioned_docs/version-1.21.4/datastorage/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Data Storage",
-    "position": 8
+    "position": 9
 }

--- a/versioned_docs/version-1.21.4/entities/attributes.md
+++ b/versioned_docs/version-1.21.4/entities/attributes.md
@@ -246,7 +246,7 @@ The same rules also apply for any other `Attribute` subclass, i.e., we generally
 :::
 
 [custom]: #custom-attributes
-[equipment]: ../blockentities/container.md#containers-on-entitys
+[equipment]: ../inventories/container.md#containers-on-entitys
 [event]: ../concepts/events.md
 [livingentity]: livingentity.md
 [loottables]: ../resources/server/loottables/index.md

--- a/versioned_docs/version-1.21.4/entities/livingentity.md
+++ b/versioned_docs/version-1.21.4/entities/livingentity.md
@@ -253,7 +253,7 @@ If all those checks pass, a spawn entry is chosen from the above list based on t
 [addspawns]: ../worldgen/biomemodifier.md#add-spawns
 [attributes]: attributes.md
 [clientitem]: ../resources/client/models/items.md
-[containers]: ../blockentities/container.md
+[containers]: ../inventories/container.md
 [creative]: ../items/index.md#creative-tabs
 [damage]: index.md#damaging-entities
 [damagesources]: ../resources/server/damagetypes.md#creating-and-using-damage-sources

--- a/versioned_docs/version-1.21.4/gui/_category_.json
+++ b/versioned_docs/version-1.21.4/gui/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "GUIs",
-    "position": 9
+    "position": 10
 }

--- a/versioned_docs/version-1.21.4/gui/menus.md
+++ b/versioned_docs/version-1.21.4/gui/menus.md
@@ -347,7 +347,7 @@ Once again, this is the simplest way to implement the logic, not the only way.
 [acm]: #abstractcontainermenu
 [mt]: #menutype
 [qms]: #quickmovestack
-[cap]: ../datastorage/capabilities.md#neoforge-provided-capabilities
+[cap]: ../inventories/capabilities.md#neoforge-provided-capabilities
 [screen]: screens.md
 [icf]: #icontainerfactory
 [side]: ../concepts/sides.md#the-logical-side

--- a/versioned_docs/version-1.21.4/inventories/_category_.json
+++ b/versioned_docs/version-1.21.4/inventories/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Inventories & Transfers",
+    "position": 8
+}

--- a/versioned_docs/version-1.21.4/inventories/capabilities.md
+++ b/versioned_docs/version-1.21.4/inventories/capabilities.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 2
 ---
 # Capabilities
 
@@ -325,15 +325,13 @@ Providers are asked for a capability in the order that they are registered. Shou
 For example:
 
 ```java
-// use HIGH priority to register before NeoForge!
-@SubscribeEvent(priority = EventPriority.HIGH) // on the mod event bus
-public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+modBus.addListener(RegisterCapabilitiesEvent.class, event -> {
     event.registerItem(
         Capabilities.FluidHandler.ITEM,
         (stack, ctx) -> new MyCustomFluidBucketWrapper(stack),
         // blocks to register for
         MY_CUSTOM_BUCKET);
-}
+}, EventPriority.HIGH); // use HIGH priority to register before NeoForge!
 ```
 
 See [`CapabilityHooks`][capability-hooks] for a list of the providers registered by NeoForge itself.

--- a/versioned_docs/version-1.21.4/inventories/container.md
+++ b/versioned_docs/version-1.21.4/inventories/container.md
@@ -1,6 +1,9 @@
+---
+sidebar_position: 1
+---
 # Containers
 
-A popular use case of [block entities][blockentity] is to store items of some kind. Some of the most essential [blocks][block] in Minecraft, such as the furnace or the chest, use block entities for this purpose. To store items on something, Minecraft uses `Container`s.
+Many systems in Minecraft, such as [block entities][blockentity] or [entities][entity], store items of some kind. To store items on something, Minecraft uses `Container` implementations.
 
 The `Container` interface defines methods such as `#getItem`, `#setItem` and `#removeItem` that can be used to query and update the container. Since it is an interface, it does not actually contain a backing list or other data structure, that is up to the implementing system.
 
@@ -156,10 +159,6 @@ public class MyBlockEntity extends BaseContainerBlockEntity {
 
 Keep in mind that this class is a `BlockEntity` and a `Container` at the same time. This means that you can use the class as a supertype for your block entity to get a functioning block entity with a pre-implemented container.
 
-:::note
-`BlockEntity`s that implement `Container` handle dropping their contents by default. If you choose not to implement `Container`, then you will need to handle the [removal logic][beremove].
-:::
-
 ### `WorldlyContainer`
 
 `WorldlyContainer` is a sub-interface of `Container` that allows accessing slots of the given `Container` by `Direction`. It is mainly intended for block entities that only expose parts of their container to a particular side. For example, this could be used by a machine that outputs to one side and takes inputs from all other sides, or vice-versa. A simple implementation of the interface could look like this:
@@ -299,16 +298,15 @@ mob.setDropChance(EquipmentSlot.FEET, 1f);
 
 The player's inventory is implemented through the `Inventory` class, a class implementing `Container` as well as the `Nameable` interface mentioned earlier. An instance of that `Inventory` is then stored as a field named `inventory` on the `Player`, accessible via `Player#getInventory`. The inventory can be interacted with like any other container.
 
-The inventory contents are stored in two places:
+The inventory contents are stored in three `public final NonNullList<ItemStack>`s:
 
-- The `NonNullList<ItemStack> items` list covers the 36 main inventory slots, including the nine hotbar slots (indices 0-8).
-- The `EntityEquipment equipment` map stores the `EquipmentSlot` stacks: the armor slots (`FEET`, `LEGS`, `CHEST`, `HEAD`), `OFFHAND`, `BODY`, and `SADDLE`, in that order.  
+- The `items` list covers the 36 main inventory slots, including the nine hotbar slots (indices 0-8).
+- The `armor` list is a list of length 4, containing armor for the `FEET`, `LEGS`, `CHEST`, and `HEAD`, in that order. This list uses `EquipmentSlot` accessors, similar to `Mob`s (see above).
+- The `offhand` list contains only the offhand slot, i.e. has a length of 1.
 
-When iterating over the inventory contents, it is recommended to iterate over `items`, then over `equipment` using `Inventory#EQUIPMENT_SLOT_MAPPING` for the indices.
+When iterating over the inventory contents, it is recommended to iterate over `items`, then over `armor` and then over `offhand`, to be consistent with vanilla behavior.
 
-[beremove]: index.md#removing-block-entities
-[block]: ../blocks/index.md
-[blockentity]: index.md
+[blockentity]: ../blockentities/index.md
 [component]: ../resources/client/i18n.md#components
 [datacomponent]: ../items/datacomponents.md
 [entity]: ../entities/index.md

--- a/versioned_docs/version-1.21.4/misc/_category_.json
+++ b/versioned_docs/version-1.21.4/misc/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Miscellaneous",
-    "position": 13
+    "position": 14
 }

--- a/versioned_docs/version-1.21.4/networking/_category_.json
+++ b/versioned_docs/version-1.21.4/networking/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Networking",
-    "position": 11
+    "position": 12
 }

--- a/versioned_docs/version-1.21.4/resources/client/models/items.md
+++ b/versioned_docs/version-1.21.4/resources/client/models/items.md
@@ -1491,7 +1491,7 @@ protected void registerModels(BlockModelGenerators blockModels, ItemModelGenerat
 [assets]: ../../index.md#assets
 [bakedmodels]: ../models/bakedmodel.md
 [ber]: ../../../blockentities/ber.md
-[capability]: ../../../datastorage/capabilities.md#registering-capabilities
+[capability]: ../../../inventories/capabilities.md#registering-capabilities
 [composite]: modelloaders.md#composite-model
 [itemmodel]: #manually-rendering-an-item
 [modbus]: ../../../concepts/events.md#event-buses

--- a/versioned_docs/version-1.21.4/worldgen/_category_.json
+++ b/versioned_docs/version-1.21.4/worldgen/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Worldgen",
-    "position": 10
+    "position": 11
 }

--- a/versioned_docs/version-1.21.5/advanced/_category_.json
+++ b/versioned_docs/version-1.21.5/advanced/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Advanced Topics",
-    "position": 12
+    "position": 13
 }

--- a/versioned_docs/version-1.21.5/blockentities/index.md
+++ b/versioned_docs/version-1.21.5/blockentities/index.md
@@ -271,7 +271,7 @@ It is important that you do safety checks, as the `BlockEntity` might already be
 [block]: ../blocks/index.md
 [blockreg]: ../blocks/index.md#basic-blocks
 [blockstate]: ../blocks/states.md
-[container]: container.md
+[container]: ../inventories/container.md
 [dataattachments]: ../datastorage/attachments.md
 [entities]: ../entities/index.md
 [modbus]: ../concepts/events.md#event-buses

--- a/versioned_docs/version-1.21.5/datastorage/_category_.json
+++ b/versioned_docs/version-1.21.5/datastorage/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Data Storage",
-    "position": 8
+    "position": 9
 }

--- a/versioned_docs/version-1.21.5/entities/attributes.md
+++ b/versioned_docs/version-1.21.5/entities/attributes.md
@@ -246,7 +246,7 @@ The same rules also apply for any other `Attribute` subclass, i.e., we generally
 :::
 
 [custom]: #custom-attributes
-[equipment]: ../blockentities/container.md#containers-on-entitys
+[equipment]: ../inventories/container.md#containers-on-entitys
 [event]: ../concepts/events.md
 [livingentity]: livingentity.md
 [loottables]: ../resources/server/loottables/index.md

--- a/versioned_docs/version-1.21.5/entities/livingentity.md
+++ b/versioned_docs/version-1.21.5/entities/livingentity.md
@@ -253,7 +253,7 @@ If all those checks pass, a spawn entry is chosen from the above list based on t
 [addspawns]: ../worldgen/biomemodifier.md#add-spawns
 [attributes]: attributes.md
 [clientitem]: ../resources/client/models/items.md
-[containers]: ../blockentities/container.md
+[containers]: ../inventories/container.md
 [creative]: ../items/index.md#creative-tabs
 [damage]: index.md#damaging-entities
 [damagesources]: ../resources/server/damagetypes.md#creating-and-using-damage-sources

--- a/versioned_docs/version-1.21.5/gui/_category_.json
+++ b/versioned_docs/version-1.21.5/gui/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "GUIs",
-    "position": 9
+    "position": 10
 }

--- a/versioned_docs/version-1.21.5/gui/menus.md
+++ b/versioned_docs/version-1.21.5/gui/menus.md
@@ -347,7 +347,7 @@ Once again, this is the simplest way to implement the logic, not the only way.
 [acm]: #abstractcontainermenu
 [mt]: #menutype
 [qms]: #quickmovestack
-[cap]: ../datastorage/capabilities.md#neoforge-provided-capabilities
+[cap]: ../inventories/capabilities.md#neoforge-provided-capabilities
 [screen]: screens.md
 [icf]: #icontainerfactory
 [side]: ../concepts/sides.md#the-logical-side

--- a/versioned_docs/version-1.21.5/inventories/_category_.json
+++ b/versioned_docs/version-1.21.5/inventories/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Inventories & Transfers",
+    "position": 8
+}

--- a/versioned_docs/version-1.21.5/inventories/capabilities.md
+++ b/versioned_docs/version-1.21.5/inventories/capabilities.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 2
 ---
 # Capabilities
 
@@ -257,7 +257,7 @@ They need to be registered in the `RegisterCapabilitiesEvent`.
 Block providers are registered with `registerBlock`. For example:
 
 ```java
-@SubscribeEvent  // on the mod event bus
+@SubscribeEvent // on the mod event bus
 public static void registerCapabilities(RegisterCapabilitiesEvent event) {
     event.registerBlock(
         Capabilities.ItemHandler.BLOCK, // capability to register for

--- a/versioned_docs/version-1.21.5/inventories/container.md
+++ b/versioned_docs/version-1.21.5/inventories/container.md
@@ -1,6 +1,9 @@
+---
+sidebar_position: 1
+---
 # Containers
 
-A popular use case of [block entities][blockentity] is to store items of some kind. Some of the most essential [blocks][block] in Minecraft, such as the furnace or the chest, use block entities for this purpose. To store items on something, Minecraft uses `Container`s.
+Many systems in Minecraft, such as [block entities][blockentity] or [entities][entity], store items of some kind. To store items on something, Minecraft uses `Container` implementations.
 
 The `Container` interface defines methods such as `#getItem`, `#setItem` and `#removeItem` that can be used to query and update the container. Since it is an interface, it does not actually contain a backing list or other data structure, that is up to the implementing system.
 
@@ -156,6 +159,10 @@ public class MyBlockEntity extends BaseContainerBlockEntity {
 
 Keep in mind that this class is a `BlockEntity` and a `Container` at the same time. This means that you can use the class as a supertype for your block entity to get a functioning block entity with a pre-implemented container.
 
+:::note
+`BlockEntity`s that implement `Container` handle dropping their contents by default. If you choose not to implement `Container`, then you will need to handle the [removal logic][beremove].
+:::
+
 ### `WorldlyContainer`
 
 `WorldlyContainer` is a sub-interface of `Container` that allows accessing slots of the given `Container` by `Direction`. It is mainly intended for block entities that only expose parts of their container to a particular side. For example, this could be used by a machine that outputs to one side and takes inputs from all other sides, or vice-versa. A simple implementation of the interface could look like this:
@@ -264,7 +271,7 @@ Be aware that menus that directly interface with `Container`s must `#copy()` the
 
 ## `Container`s on `Entity`s
 
-`Container`s on `Entity`s are finicky: whether an entity has a container or not cannot be universally determined. It all depends on what entity you are handling, and as such can require a lot of special-casing.
+`Container`s on [`Entity`s][entity] are finicky: whether an entity has a container or not cannot be universally determined. It all depends on what entity you are handling, and as such can require a lot of special-casing.
 
 If you are creating an entity yourself, there is nothing stopping you from implementing `Container` on it directly, though be aware that you will not be able to use superclasses such as `SimpleContainer` (since `Entity` is the superclass).
 
@@ -303,10 +310,11 @@ The inventory contents are stored in three `public final NonNullList<ItemStack>`
 
 When iterating over the inventory contents, it is recommended to iterate over `items`, then over `armor` and then over `offhand`, to be consistent with vanilla behavior.
 
-[block]: ../blocks/index.md
-[blockentity]: index.md
+[beremove]: ../blockentities/index.md#removing-block-entities
+[blockentity]: ../blockentities/index.md
 [component]: ../resources/client/i18n.md#components
 [datacomponent]: ../items/datacomponents.md
+[entity]: ../entities/index.md
 [item]: ../items/index.md
 [itemstack]: ../items/index.md#itemstacks
 [menu]: ../gui/menus.md

--- a/versioned_docs/version-1.21.5/misc/_category_.json
+++ b/versioned_docs/version-1.21.5/misc/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Miscellaneous",
-    "position": 13
+    "position": 14
 }

--- a/versioned_docs/version-1.21.5/networking/_category_.json
+++ b/versioned_docs/version-1.21.5/networking/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Networking",
-    "position": 11
+    "position": 12
 }

--- a/versioned_docs/version-1.21.5/resources/client/models/items.md
+++ b/versioned_docs/version-1.21.5/resources/client/models/items.md
@@ -1500,7 +1500,7 @@ protected void registerModels(BlockModelGenerators blockModels, ItemModelGenerat
 
 [assets]: ../../index.md#assets
 [ber]: ../../../blockentities/ber.md
-[capability]: ../../../datastorage/capabilities.md#registering-capabilities
+[capability]: ../../../inventories/capabilities.md#registering-capabilities
 [composite]: modelloaders.md#composite-model
 [itemmodel]: #manually-rendering-an-item
 [modbus]: ../../../concepts/events.md#event-buses

--- a/versioned_docs/version-1.21.5/worldgen/_category_.json
+++ b/versioned_docs/version-1.21.5/worldgen/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Worldgen",
-    "position": 10
+    "position": 11
 }

--- a/versioned_docs/version-1.21.8/advanced/_category_.json
+++ b/versioned_docs/version-1.21.8/advanced/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Advanced Topics",
-    "position": 12
+    "position": 13
 }

--- a/versioned_docs/version-1.21.8/blockentities/index.md
+++ b/versioned_docs/version-1.21.8/blockentities/index.md
@@ -267,7 +267,7 @@ It is important that you do safety checks, as the `BlockEntity` might already be
 [block]: ../blocks/index.md
 [blockreg]: ../blocks/index.md#basic-blocks
 [blockstate]: ../blocks/states.md
-[container]: container.md
+[container]: ../inventories/container.md
 [dataattachments]: ../datastorage/attachments.md
 [entities]: ../entities/index.md
 [modbus]: ../concepts/events.md#event-buses

--- a/versioned_docs/version-1.21.8/datastorage/_category_.json
+++ b/versioned_docs/version-1.21.8/datastorage/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Data Storage",
-    "position": 8
+    "position": 9
 }

--- a/versioned_docs/version-1.21.8/entities/attributes.md
+++ b/versioned_docs/version-1.21.8/entities/attributes.md
@@ -248,7 +248,7 @@ The same rules also apply for any other `Attribute` subclass, i.e., we generally
 :::
 
 [custom]: #custom-attributes
-[equipment]: ../blockentities/container.md#containers-on-entitys
+[equipment]: ../inventories/container.md#containers-on-entitys
 [event]: ../concepts/events.md
 [livingentity]: livingentity.md
 [loottables]: ../resources/server/loottables/index.md

--- a/versioned_docs/version-1.21.8/entities/livingentity.md
+++ b/versioned_docs/version-1.21.8/entities/livingentity.md
@@ -252,7 +252,7 @@ If all those checks pass, a spawn entry is chosen from the above list based on t
 [addspawns]: ../worldgen/biomemodifier.md#add-spawns
 [attributes]: attributes.md
 [clientitem]: ../resources/client/models/items.md
-[containers]: ../blockentities/container.md
+[containers]: ../inventories/container.md
 [creative]: ../items/index.md#creative-tabs
 [damage]: index.md#damaging-entities
 [damagesources]: ../resources/server/damagetypes.md#creating-and-using-damage-sources

--- a/versioned_docs/version-1.21.8/gui/_category_.json
+++ b/versioned_docs/version-1.21.8/gui/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "GUIs",
-    "position": 9
+    "position": 10
 }

--- a/versioned_docs/version-1.21.8/gui/menus.md
+++ b/versioned_docs/version-1.21.8/gui/menus.md
@@ -408,7 +408,7 @@ Once again, this is the simplest way to implement the logic, not the only way.
 [acm]: #abstractcontainermenu
 [mt]: #menutype
 [qms]: #quickmovestack
-[cap]: ../datastorage/capabilities.md#neoforge-provided-capabilities
+[cap]: ../inventories/capabilities.md#neoforge-provided-capabilities
 [screen]: screens.md
 [icf]: #icontainerfactory
 [side]: ../concepts/sides.md#the-logical-side

--- a/versioned_docs/version-1.21.8/inventories/_category_.json
+++ b/versioned_docs/version-1.21.8/inventories/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "Inventories & Transfers",
+    "position": 8
+}

--- a/versioned_docs/version-1.21.8/inventories/capabilities.md
+++ b/versioned_docs/version-1.21.8/inventories/capabilities.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 2
 ---
 # Capabilities
 
@@ -325,13 +325,15 @@ Providers are asked for a capability in the order that they are registered. Shou
 For example:
 
 ```java
-modBus.addListener(RegisterCapabilitiesEvent.class, event -> {
+// use HIGH priority to register before NeoForge!
+@SubscribeEvent(priority = EventPriority.HIGH) // on the mod event bus
+public static void registerCapabilities(RegisterCapabilitiesEvent event) {
     event.registerItem(
         Capabilities.FluidHandler.ITEM,
         (stack, ctx) -> new MyCustomFluidBucketWrapper(stack),
         // blocks to register for
         MY_CUSTOM_BUCKET);
-}, EventPriority.HIGH); // use HIGH priority to register before NeoForge!
+}
 ```
 
 See [`CapabilityHooks`][capability-hooks] for a list of the providers registered by NeoForge itself.

--- a/versioned_docs/version-1.21.8/inventories/container.md
+++ b/versioned_docs/version-1.21.8/inventories/container.md
@@ -1,6 +1,9 @@
+---
+sidebar_position: 1
+---
 # Containers
 
-A popular use case of [block entities][blockentity] is to store items of some kind. Some of the most essential [blocks][block] in Minecraft, such as the furnace or the chest, use block entities for this purpose. To store items on something, Minecraft uses `Container`s.
+Many systems in Minecraft, such as [block entities][blockentity] or [entities][entity], store items of some kind. To store items on something, Minecraft uses `Container` implementations.
 
 The `Container` interface defines methods such as `#getItem`, `#setItem` and `#removeItem` that can be used to query and update the container. Since it is an interface, it does not actually contain a backing list or other data structure, that is up to the implementing system.
 
@@ -156,6 +159,10 @@ public class MyBlockEntity extends BaseContainerBlockEntity {
 
 Keep in mind that this class is a `BlockEntity` and a `Container` at the same time. This means that you can use the class as a supertype for your block entity to get a functioning block entity with a pre-implemented container.
 
+:::note
+`BlockEntity`s that implement `Container` handle dropping their contents by default. If you choose not to implement `Container`, then you will need to handle the [removal logic][beremove].
+:::
+
 ### `WorldlyContainer`
 
 `WorldlyContainer` is a sub-interface of `Container` that allows accessing slots of the given `Container` by `Direction`. It is mainly intended for block entities that only expose parts of their container to a particular side. For example, this could be used by a machine that outputs to one side and takes inputs from all other sides, or vice-versa. A simple implementation of the interface could look like this:
@@ -295,16 +302,15 @@ mob.setDropChance(EquipmentSlot.FEET, 1f);
 
 The player's inventory is implemented through the `Inventory` class, a class implementing `Container` as well as the `Nameable` interface mentioned earlier. An instance of that `Inventory` is then stored as a field named `inventory` on the `Player`, accessible via `Player#getInventory`. The inventory can be interacted with like any other container.
 
-The inventory contents are stored in three `public final NonNullList<ItemStack>`s:
+The inventory contents are stored in two places:
 
-- The `items` list covers the 36 main inventory slots, including the nine hotbar slots (indices 0-8).
-- The `armor` list is a list of length 4, containing armor for the `FEET`, `LEGS`, `CHEST`, and `HEAD`, in that order. This list uses `EquipmentSlot` accessors, similar to `Mob`s (see above).
-- The `offhand` list contains only the offhand slot, i.e. has a length of 1.
+- The `NonNullList<ItemStack> items` list covers the 36 main inventory slots, including the nine hotbar slots (indices 0-8).
+- The `EntityEquipment equipment` map stores the `EquipmentSlot` stacks: the armor slots (`FEET`, `LEGS`, `CHEST`, `HEAD`), `OFFHAND`, `BODY`, and `SADDLE`, in that order.  
 
-When iterating over the inventory contents, it is recommended to iterate over `items`, then over `armor` and then over `offhand`, to be consistent with vanilla behavior.
+When iterating over the inventory contents, it is recommended to iterate over `items`, then over `equipment` using `Inventory#EQUIPMENT_SLOT_MAPPING` for the indices.
 
-[block]: ../blocks/index.md
-[blockentity]: index.md
+[beremove]: ../blockentities/index.md#removing-block-entities
+[blockentity]: ../blockentities/index.md
 [component]: ../resources/client/i18n.md#components
 [datacomponent]: ../items/datacomponents.md
 [entity]: ../entities/index.md

--- a/versioned_docs/version-1.21.8/misc/_category_.json
+++ b/versioned_docs/version-1.21.8/misc/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Miscellaneous",
-    "position": 13
+    "position": 14
 }

--- a/versioned_docs/version-1.21.8/networking/_category_.json
+++ b/versioned_docs/version-1.21.8/networking/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Networking",
-    "position": 11
+    "position": 12
 }

--- a/versioned_docs/version-1.21.8/resources/client/models/items.md
+++ b/versioned_docs/version-1.21.8/resources/client/models/items.md
@@ -1541,7 +1541,7 @@ protected void registerModels(BlockModelGenerators blockModels, ItemModelGenerat
 
 [assets]: ../../index.md#assets
 [ber]: ../../../blockentities/ber.md
-[capability]: ../../../datastorage/capabilities.md#registering-capabilities
+[capability]: ../../../inventories/capabilities.md#registering-capabilities
 [composite]: modelloaders.md#composite-model
 [itemmodel]: #manually-rendering-an-item
 [modbus]: ../../../concepts/events.md#event-buses

--- a/versioned_docs/version-1.21.8/worldgen/_category_.json
+++ b/versioned_docs/version-1.21.8/worldgen/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Worldgen",
-    "position": 10
+    "position": 11
 }


### PR DESCRIPTION
This PR:
- Adds a new category named Inventories & Transfers, ordered between the Resources and Data Storage categories. It contains the following articles in order:
  - Containers (moved from the Block Entities category)
  - Capabilities (moved from the Data Storage category)
  - Menus (moved from the GUI category)
  - Transactions (to be written, see #293 )
- Moves the Screens article into the Rendering category, effectively removing the GUI category.
- In the Containers article, adjusts the introduction to make it less dependent on being in the Block Entities category.
- The changes are also applied to all versions back until 1.21.1, except for moving the Menus and Screens articles (due to lack of a Rendering category to move Screens into instead on those versions).

------------------
Preview URL: https://pr-303.neoforged-docs-previews.pages.dev