### PR TITLE
Fix references in blocks and items articles

### DIFF
--- a/docs/blocks/index.md
+++ b/docs/blocks/index.md
@@ -197,7 +197,15 @@ This does the exact same as the previous example, but is slightly shorter. Of co
 
 ### Resources
 
-If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. To apply the texture to the block, you must provide a [model] and a [blockstate file][bsfile] that associates the block with the texture and a shape. Give the linked articles a read for more information.
+If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. When adding a new block in Minecraft, you should either write or [generate][datagen] the following files:
+
+- A [blockstate file][bsfile]
+- A [block model][model]
+- A [translation][i18n]
+- A [loot table][loottable]
+- Some block [tags], e.g. for mining
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## Using Blocks
 
@@ -358,14 +366,18 @@ Random ticking is used by a wide range of mechanics in Minecraft, such as plant 
 [blockstates]: states.md
 [bsfile]: ../resources/client/models/index.md#blockstate-files
 [codec]: ../datastorage/codecs.md#records
+[datagen]: ../resources/index.md#data-generation
+[i18n]: ../resources/client/i18n.md
 [item]: ../items/index.md
 [leftclick]: ../items/interactions.md#left-clicking-an-item
+[loottable]: ../resources/server/loottables/index.md
 [model]: ../resources/client/models/index.md
 [randomtick]: #random-ticking
 [registration]: ../concepts/registries.md#methods-for-registering
 [resources]: ../resources/index.md#assets
 [rightclick]: ../items/interactions.md#right-clicking-an-item
 [sounds]: ../resources/client/sounds.md
+[tags]: ../resources/server/tags.md
 [textures]: ../resources/client/textures.md
 [tool]: ../items/tools.md
 [usingblocks]: #using-blocks

--- a/docs/items/index.md
+++ b/docs/items/index.md
@@ -134,7 +134,14 @@ If you keep your registered blocks in a separate class, you should classload you
 
 If you register your item and get your item (via `/give` or through a [creative tab][creativetabs]), you will find it to be missing a proper model and texture. This is because textures and models are handled by Minecraft's resource system.
 
-To apply a simple texture to an item, you must create a client item, model JSON, and a texture PNG. See the section on [client items][citems] for more information.
+For every item, you will want to add - or [generate][datagen] - JSON files for the following:
+
+- A [client item][citems] with an associated [texture]
+- A [translation][i18n]
+- A [recipe][recipes] (optional)
+- Some item [tags] (optional)
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## `ItemStack`s
 
@@ -254,3 +261,7 @@ It is also possible to implement `ItemLike` on your custom objects. Simply overr
 [registering]: ../concepts/registries.md#methods-for-registering
 [sides]: ../concepts/sides.md
 [tools]: tools.md
+[datagen]: ../resources/index.md#data-generation
+[i18n]: ../resources/client/i18n.md
+[texture]: ../resources/client/textures.md
+[tags]: ../resources/server/tags.md

--- a/versioned_docs/version-1.21.1/blocks/index.md
+++ b/versioned_docs/version-1.21.1/blocks/index.md
@@ -188,7 +188,15 @@ This does the exact same as the previous example, but is slightly shorter. Of co
 
 ### Resources
 
-If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. To apply the texture to the block, you must provide a [model] and a [blockstate file][bsfile] that associates the block with the texture and a shape. Give the linked articles a read for more information.
+If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. When adding a new block in Minecraft, you should either write or [generate][datagen] the following files:
+
+- A [blockstate file][bsfile]
+- A [block model][model]
+- A [translation][i18n]
+- A [loot table][loottable]
+- Some block [tags], e.g. for mining
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## Using Blocks
 
@@ -300,14 +308,18 @@ Random ticking is used by a wide range of mechanics in Minecraft, such as plant 
 [blockstates]: states.md
 [bsfile]: ../resources/client/models/index.md#blockstate-files
 [codec]: ../datastorage/codecs.md#records
+[datagen]: ../resources/index.md#data-generation
 [events]: ../concepts/events.md
+[i18n]: ../resources/client/i18n.md
 [interactionpipeline]: ../items/interactionpipeline.md
 [item]: ../items/index.md
+[loottable]: ../resources/server/loottables/index.md
 [model]: ../resources/client/models/index.md
 [randomtick]: #random-ticking
 [registration]: ../concepts/registries.md#methods-for-registering
 [resources]: ../resources/index.md#assets
 [sounds]: ../resources/client/sounds.md
+[tags]: ../resources/server/tags.md
 [textures]: ../resources/client/textures.md
 [usingblocks]: #using-blocks
 [usingblockstates]: states.md#using-blockstates

--- a/versioned_docs/version-1.21.1/items/index.md
+++ b/versioned_docs/version-1.21.1/items/index.md
@@ -120,7 +120,14 @@ If you keep your registered blocks in a separate class, you should classload you
 
 If you register your item and get your item (via `/give` or through a [creative tab][creativetabs]), you will find it to be missing a proper model and texture. This is because textures and models  are handled by Minecraft's resource system.
 
-To apply a simple texture to an item, you must add an item model JSON and a texture PNG. See the section on [resources][resources] for more information.
+For every item, you will want to add - or [generate][datagen] - JSON files for the following:
+
+- An [item model][model] with an associated [texture]
+- A [translation][i18n]
+- A [recipe][recipes] (optional)
+- Some item [tags] (optional)
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## `ItemStack`s
 
@@ -229,12 +236,16 @@ It is also possible to implement `ItemLike` on your custom objects. Simply overr
 [datagen]: ../resources/index.md#data-generation
 [food]: #food
 [hunger]: https://minecraft.wiki/w/Hunger#Mechanics
+[i18n]: ../resources/client/i18n.md
 [interactionpipeline]: interactionpipeline.md
 [loottables]: ../resources/server/loottables/index.md
 [mobeffectinstance]: mobeffects.md#mobeffectinstances
 [modbus]: ../concepts/events.md#event-buses
+[model]: ../resources/client/models/index.md
 [recipes]: ../resources/server/recipes/index.md
 [registering]: ../concepts/registries.md#methods-for-registering
 [resources]: ../resources/index.md#assets
 [sides]: ../concepts/sides.md
+[tags]: ../resources/server/tags.md
+[texture]: ../resources/client/textures.md
 [wikicomponents]: https://minecraft.wiki/w/Data_component_format

--- a/versioned_docs/version-1.21.3/blocks/index.md
+++ b/versioned_docs/version-1.21.3/blocks/index.md
@@ -199,7 +199,15 @@ This does the exact same as the previous example, but is slightly shorter. Of co
 
 ### Resources
 
-If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. To apply the texture to the block, you must provide a [model] and a [blockstate file][bsfile] that associates the block with the texture and a shape. Give the linked articles a read for more information.
+If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. When adding a new block in Minecraft, you should either write or [generate][datagen] the following files:
+
+- A [blockstate file][bsfile]
+- A [block model][model]
+- A [translation][i18n]
+- A [loot table][loottable]
+- Some block [tags], e.g. for mining
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## Using Blocks
 
@@ -311,14 +319,18 @@ Random ticking is used by a wide range of mechanics in Minecraft, such as plant 
 [blockstates]: states.md
 [bsfile]: ../resources/client/models/index.md#blockstate-files
 [codec]: ../datastorage/codecs.md#records
+[datagen]: ../resources/index.md#data-generation
 [events]: ../concepts/events.md
+[i18n]: ../resources/client/i18n.md
 [interactionpipeline]: ../items/interactionpipeline.md
 [item]: ../items/index.md
+[loottable]: ../resources/server/loottables/index.md
 [model]: ../resources/client/models/index.md
 [randomtick]: #random-ticking
 [registration]: ../concepts/registries.md#methods-for-registering
 [resources]: ../resources/index.md#assets
 [sounds]: ../resources/client/sounds.md
+[tags]: ../resources/server/tags.md
 [textures]: ../resources/client/textures.md
 [usingblocks]: #using-blocks
 [usingblockstates]: states.md#using-blockstates

--- a/versioned_docs/version-1.21.3/items/index.md
+++ b/versioned_docs/version-1.21.3/items/index.md
@@ -135,7 +135,14 @@ If you keep your registered blocks in a separate class, you should classload you
 
 If you register your item and get your item (via `/give` or through a [creative tab][creativetabs]), you will find it to be missing a proper model and texture. This is because textures and models  are handled by Minecraft's resource system.
 
-To apply a simple texture to an item, you must add an item model JSON and a texture PNG. See the section on [resources][resources] for more information.
+For every item, you will want to add - or [generate][datagen] - JSON files for the following:
+
+- An [item model][model] with an associated [texture]
+- A [translation][i18n]
+- A [recipe][recipes] (optional)
+- Some item [tags] (optional)
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## `ItemStack`s
 
@@ -245,11 +252,15 @@ It is also possible to implement `ItemLike` on your custom objects. Simply overr
 [datagen]: ../resources/index.md#data-generation
 [enchantment]: ../resources/server/enchantments/index.md#enchantment-costs-and-levels
 [food]: consumables.md#food
+[i18n]: ../resources/client/i18n.md
 [interactionpipeline]: interactionpipeline.md
 [loottables]: ../resources/server/loottables/index.md
 [modbus]: ../concepts/events.md#event-buses
+[model]: ../resources/client/models/index.md
 [recipes]: ../resources/server/recipes/index.md
 [registering]: ../concepts/registries.md#methods-for-registering
 [resources]: ../resources/index.md#assets
 [sides]: ../concepts/sides.md
+[tags]: ../resources/server/tags.md
+[texture]: ../resources/client/textures.md
 [tools]: tools.md

--- a/versioned_docs/version-1.21.4/blocks/index.md
+++ b/versioned_docs/version-1.21.4/blocks/index.md
@@ -197,7 +197,15 @@ This does the exact same as the previous example, but is slightly shorter. Of co
 
 ### Resources
 
-If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. To apply the texture to the block, you must provide a [model] and a [blockstate file][bsfile] that associates the block with the texture and a shape. Give the linked articles a read for more information.
+If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. When adding a new block in Minecraft, you should either write or [generate][datagen] the following files:
+
+- A [blockstate file][bsfile]
+- A [block model][model]
+- A [translation][i18n]
+- A [loot table][loottable]
+- Some block [tags], e.g. for mining
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## Using Blocks
 
@@ -357,14 +365,18 @@ Random ticking is used by a wide range of mechanics in Minecraft, such as plant 
 [blockstates]: states.md
 [bsfile]: ../resources/client/models/index.md#blockstate-files
 [codec]: ../datastorage/codecs.md#records
+[datagen]: ../resources/index.md#data-generation
+[i18n]: ../resources/client/i18n.md
 [item]: ../items/index.md
 [leftclick]: ../items/interactions.md#left-clicking-an-item
+[loottable]: ../resources/server/loottables/index.md
 [model]: ../resources/client/models/index.md
 [randomtick]: #random-ticking
 [registration]: ../concepts/registries.md#methods-for-registering
 [resources]: ../resources/index.md#assets
 [rightclick]: ../items/interactions.md#right-clicking-an-item
 [sounds]: ../resources/client/sounds.md
+[tags]: ../resources/server/tags.md
 [textures]: ../resources/client/textures.md
 [tool]: ../items/tools.md
 [usingblocks]: #using-blocks

--- a/versioned_docs/version-1.21.4/items/index.md
+++ b/versioned_docs/version-1.21.4/items/index.md
@@ -134,7 +134,14 @@ If you keep your registered blocks in a separate class, you should classload you
 
 If you register your item and get your item (via `/give` or through a [creative tab][creativetabs]), you will find it to be missing a proper model and texture. This is because textures and models are handled by Minecraft's resource system.
 
-To apply a simple texture to an item, you must create a client item, model JSON, and a texture PNG. See the section on [client items][citems] for more information.
+For every item, you will want to add - or [generate][datagen] - JSON files for the following:
+
+- A [client item][citems] with an associated [texture]
+- A [translation][i18n]
+- A [recipe][recipes] (optional)
+- Some item [tags] (optional)
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## `ItemStack`s
 
@@ -247,10 +254,13 @@ It is also possible to implement `ItemLike` on your custom objects. Simply overr
 [entity]: ../entities/index.md
 [food]: consumables.md#food
 [hunger]: https://minecraft.wiki/w/Hunger#Mechanics
+[i18n]: ../resources/client/i18n.md
 [interactions]: interactions.md
 [loottables]: ../resources/server/loottables/index.md
 [modbus]: ../concepts/events.md#event-buses
 [recipes]: ../resources/server/recipes/index.md
 [registering]: ../concepts/registries.md#methods-for-registering
 [sides]: ../concepts/sides.md
+[tags]: ../resources/server/tags.md
+[texture]: ../resources/client/textures.md
 [tools]: tools.md

--- a/versioned_docs/version-1.21.5/blocks/index.md
+++ b/versioned_docs/version-1.21.5/blocks/index.md
@@ -197,7 +197,15 @@ This does the exact same as the previous example, but is slightly shorter. Of co
 
 ### Resources
 
-If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. To apply the texture to the block, you must provide a [model] and a [blockstate file][bsfile] that associates the block with the texture and a shape. Give the linked articles a read for more information.
+If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. When adding a new block in Minecraft, you should either write or [generate][datagen] the following files:
+
+- A [blockstate file][bsfile]
+- A [block model][model]
+- A [translation][i18n]
+- A [loot table][loottable]
+- Some block [tags], e.g. for mining
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## Using Blocks
 
@@ -357,14 +365,18 @@ Random ticking is used by a wide range of mechanics in Minecraft, such as plant 
 [blockstates]: states.md
 [bsfile]: ../resources/client/models/index.md#blockstate-files
 [codec]: ../datastorage/codecs.md#records
+[datagen]: ../resources/index.md#data-generation
+[i18n]: ../resources/client/i18n.md
 [item]: ../items/index.md
 [leftclick]: ../items/interactions.md#left-clicking-an-item
+[loottable]: ../resources/server/loottables/index.md
 [model]: ../resources/client/models/index.md
 [randomtick]: #random-ticking
 [registration]: ../concepts/registries.md#methods-for-registering
 [resources]: ../resources/index.md#assets
 [rightclick]: ../items/interactions.md#right-clicking-an-item
 [sounds]: ../resources/client/sounds.md
+[tags]: ../resources/server/tags.md
 [textures]: ../resources/client/textures.md
 [tool]: ../items/tools.md
 [usingblocks]: #using-blocks

--- a/versioned_docs/version-1.21.5/items/index.md
+++ b/versioned_docs/version-1.21.5/items/index.md
@@ -134,7 +134,14 @@ If you keep your registered blocks in a separate class, you should classload you
 
 If you register your item and get your item (via `/give` or through a [creative tab][creativetabs]), you will find it to be missing a proper model and texture. This is because textures and models are handled by Minecraft's resource system.
 
-To apply a simple texture to an item, you must create a client item, model JSON, and a texture PNG. See the section on [client items][citems] for more information.
+For every item, you will want to add - or [generate][datagen] - JSON files for the following:
+
+- A [client item][citems] with an associated [texture]
+- A [translation][i18n]
+- A [recipe][recipes] (optional)
+- Some item [tags] (optional)
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## `ItemStack`s
 
@@ -243,14 +250,18 @@ It is also possible to implement `ItemLike` on your custom objects. Simply overr
 [creativetabs]: #creative-tabs
 [datacomponents]: datacomponents.md
 [datagen]: ../resources/index.md#data-generation
+[datagen]: ../resources/index.md#data-generation
 [enchantment]: ../resources/server/enchantments/index.md#enchantment-costs-and-levels
 [entity]: ../entities/index.md
 [food]: consumables.md#food
 [hunger]: https://minecraft.wiki/w/Hunger#Mechanics
+[i18n]: ../resources/client/i18n.md
 [interactions]: interactions.md
 [loottables]: ../resources/server/loottables/index.md
 [modbus]: ../concepts/events.md#event-buses
 [recipes]: ../resources/server/recipes/index.md
 [registering]: ../concepts/registries.md#methods-for-registering
 [sides]: ../concepts/sides.md
+[tags]: ../resources/server/tags.md
+[texture]: ../resources/client/textures.md
 [tools]: tools.md

--- a/versioned_docs/version-1.21.8/blocks/index.md
+++ b/versioned_docs/version-1.21.8/blocks/index.md
@@ -197,7 +197,15 @@ This does the exact same as the previous example, but is slightly shorter. Of co
 
 ### Resources
 
-If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. To apply the texture to the block, you must provide a [model] and a [blockstate file][bsfile] that associates the block with the texture and a shape. Give the linked articles a read for more information.
+If you register your block and place it in the world, you will find it to be missing things like a texture. This is because [textures], among others, are handled by Minecraft's resource system. When adding a new block in Minecraft, you should either write or [generate][datagen] the following files:
+
+- A [blockstate file][bsfile]
+- A [block model][model]
+- A [translation][i18n]
+- A [loot table][loottable]
+- Some block [tags], e.g. for mining
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## Using Blocks
 
@@ -357,14 +365,18 @@ Random ticking is used by a wide range of mechanics in Minecraft, such as plant 
 [blockstates]: states.md
 [bsfile]: ../resources/client/models/index.md#blockstate-files
 [codec]: ../datastorage/codecs.md#records
+[datagen]: ../resources/index.md#data-generation
+[i18n]: ../resources/client/i18n.md
 [item]: ../items/index.md
 [leftclick]: ../items/interactions.md#left-clicking-an-item
+[loottable]: ../resources/server/loottables/index.md
 [model]: ../resources/client/models/index.md
 [randomtick]: #random-ticking
 [registration]: ../concepts/registries.md#methods-for-registering
 [resources]: ../resources/index.md#assets
 [rightclick]: ../items/interactions.md#right-clicking-an-item
 [sounds]: ../resources/client/sounds.md
+[tags]: ../resources/server/tags.md
 [textures]: ../resources/client/textures.md
 [tool]: ../items/tools.md
 [usingblocks]: #using-blocks

--- a/versioned_docs/version-1.21.8/items/index.md
+++ b/versioned_docs/version-1.21.8/items/index.md
@@ -134,7 +134,14 @@ If you keep your registered blocks in a separate class, you should classload you
 
 If you register your item and get your item (via `/give` or through a [creative tab][creativetabs]), you will find it to be missing a proper model and texture. This is because textures and models are handled by Minecraft's resource system.
 
-To apply a simple texture to an item, you must create a client item, model JSON, and a texture PNG. See the section on [client items][citems] for more information.
+For every item, you will want to add - or [generate][datagen] - JSON files for the following:
+
+- A [client item][citems] with an associated [texture]
+- A [translation][i18n]
+- A [recipe][recipes] (optional)
+- Some item [tags] (optional)
+
+For all of the above, also reference the files and data generators of similar vanilla blocks.
 
 ## `ItemStack`s
 
@@ -243,14 +250,18 @@ It is also possible to implement `ItemLike` on your custom objects. Simply overr
 [creativetabs]: #creative-tabs
 [datacomponents]: datacomponents.md
 [datagen]: ../resources/index.md#data-generation
+[datagen]: ../resources/index.md#data-generation
 [enchantment]: ../resources/server/enchantments/index.md#enchantment-costs-and-levels
 [entity]: ../entities/index.md
 [food]: consumables.md#food
 [hunger]: https://minecraft.wiki/w/Hunger#Mechanics
+[i18n]: ../resources/client/i18n.md
 [interactions]: interactions.md
 [loottables]: ../resources/server/loottables/index.md
 [modbus]: ../concepts/events.md#event-buses
 [recipes]: ../resources/server/recipes/index.md
 [registering]: ../concepts/registries.md#methods-for-registering
 [sides]: ../concepts/sides.md
+[tags]: ../resources/server/tags.md
+[texture]: ../resources/client/textures.md
 [tools]: tools.md


### PR DESCRIPTION
It has been a long time since I wrote the original blocks and items articles. Since then, many articles have been added, including the entire Resources section. This PR updates the blocks and items articles to include proper references to them. Changes have been backported until 1.21.1. 1.21.1 and 1.21.3 also properly mention item models instead of client items, which were added in 1.21.4. Closes #219 .

------------------
Preview URL: https://pr-304.neoforged-docs-previews.pages.dev