### PR TITLE
Update config example to register CONFIG_SPEC

### DIFF
--- a/docs/misc/config.md
+++ b/docs/misc/config.md
@@ -124,7 +124,7 @@ Once a `ModConfigSpec` has been built, it must be registered to allow NeoForge t
 public ExampleMod(ModContainer container) {
     ...
     //Register the config
-    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG);
+    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG_SPEC);
     ...
 }
 ```

--- a/versioned_docs/version-1.21.1/misc/config.md
+++ b/versioned_docs/version-1.21.1/misc/config.md
@@ -118,7 +118,7 @@ Once a `ModConfigSpec` has been built, it must be registered to allow NeoForge t
 public ExampleMod(ModContainer container) {
     ...
     //Register the config
-    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG);
+    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG_SPEC);
     ...
 }
 ```

--- a/versioned_docs/version-1.21.3/misc/config.md
+++ b/versioned_docs/version-1.21.3/misc/config.md
@@ -123,7 +123,7 @@ Once a `ModConfigSpec` has been built, it must be registered to allow NeoForge t
 public ExampleMod(ModContainer container) {
     ...
     //Register the config
-    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG);
+    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG_SPEC);
     ...
 }
 ```

--- a/versioned_docs/version-1.21.4/misc/config.md
+++ b/versioned_docs/version-1.21.4/misc/config.md
@@ -124,7 +124,7 @@ Once a `ModConfigSpec` has been built, it must be registered to allow NeoForge t
 public ExampleMod(ModContainer container) {
     ...
     //Register the config
-    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG);
+    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG_SPEC);
     ...
 }
 ```

--- a/versioned_docs/version-1.21.5/misc/config.md
+++ b/versioned_docs/version-1.21.5/misc/config.md
@@ -124,7 +124,7 @@ Once a `ModConfigSpec` has been built, it must be registered to allow NeoForge t
 public ExampleMod(ModContainer container) {
     ...
     //Register the config
-    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG);
+    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG_SPEC);
     ...
 }
 ```

--- a/versioned_docs/version-1.21.8/misc/config.md
+++ b/versioned_docs/version-1.21.8/misc/config.md
@@ -124,7 +124,7 @@ Once a `ModConfigSpec` has been built, it must be registered to allow NeoForge t
 public ExampleMod(ModContainer container) {
     ...
     //Register the config
-    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG);
+    container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG_SPEC);
     ...
 }
 ```


### PR DESCRIPTION
Update example code in documentation for config

# Issue
`container.registerConfig(ModConfig.Type.COMMON, ExampleConfig.CONFIG);` does not compile

# Fix
registerConfig accepts `IConfigSpec` not the configuration class.

Update code to pass in `ExampleConfig.CONFIG_SPEC`, instead of `ExampleConfig.CONFIG`