### PR TITLE
[Meta] Find neo news for calver formatting

### DIFF
--- a/scripts/initialize.js
+++ b/scripts/initialize.js
@@ -293,7 +293,10 @@ if (!fs.existsSync(primerDocs)) {
         
         // If a neo news article exists for that version, add it
         const versionSegments = primer.split('.');
-        const neoNews =`${versionSegments.length == 2 ? `${versionSegments[1]}.0` : `${versionSegments[1]}.${versionSegments[2]}`}release`
+        const versionExtractor = parseInt(versionSegments[0]) > 1
+            ? () => primer
+            : () => versionSegments.length == 2 ? `${versionSegments[1]}.0` : `${versionSegments[1]}.${versionSegments[2]}`
+        const neoNews =`${versionExtractor()}release`
         if (fs.existsSync(path.join(tmpPath, 'websites', `${neoNews}.md`))) {
             fs.writeFileSync(path.join(primerDocs, primer, 'neo.md'), `---
                 title: Neo Changes


### PR DESCRIPTION
The neo news articles for 26.1 onwards now use a different format for the news article paths. As such, this correctly parses and adds the articles with the new calver formatting.

------------------
Preview URL: https://pr-339.neoforged-docs-previews.pages.dev