### PR TITLE
Fix Built-in Datamap Fallback Removal Versions

### DIFF
--- a/docs/resources/server/datamaps/builtin.md
+++ b/docs/resources/server/datamaps/builtin.md
@@ -4,7 +4,7 @@ NeoForge provides various built-in [data maps][datamap] for common use cases, re
 
 ## `neoforge:acceptable_villager_distances`
 
-Allows configuring the maximum block distance that villagers will notice an entity, as a replacement for `VillagerHostilesSensor.ACCEPTABLE_DISTANCE_FROM_HOSTILES` (which will be ignored in 1.22). This data map is located at `neoforge/data_maps/entity_type/acceptable_villager_distances.json` and its objects have the following structure:
+Allows configuring the maximum block distance that villagers will notice an entity, as a replacement for `VillagerHostilesSensor.ACCEPTABLE_DISTANCE_FROM_HOSTILES` (which will be ignored in 26.2). This data map is located at `neoforge/data_maps/entity_type/acceptable_villager_distances.json` and its objects have the following structure:
 
 ```json5
 {
@@ -202,7 +202,7 @@ Example:
 
 ## `neoforge:strippables`
 
-Allows configuring the block a block will turn into when stripped (right clicked with an axe, or an item with the item ability `ItemAbilities#AXE_STRIP`), as a replacement for `AxeItem#STRIPPABLES` (which will be ignored in 1.22). This data map is located at `neoforge/data_maps/block/strippables.json` and its objects have the following structure:
+Allows configuring the block a block will turn into when stripped (right clicked with an axe, or an item with the item ability `ItemAbilities#AXE_STRIP`), as a replacement for `AxeItem#STRIPPABLES` (which will be ignored in 26.2). This data map is located at `neoforge/data_maps/block/strippables.json` and its objects have the following structure:
 
 ```json5
 {
@@ -250,7 +250,7 @@ Example:
 
 ## `neoforge:villager_types`
 
-Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 1.22). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
+Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 26.2). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
 
 ```json5
 {

--- a/versioned_docs/version-1.21.1/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.1/resources/server/datamaps/builtin.md
@@ -202,7 +202,7 @@ Example:
 
 ## `neoforge:villager_types`
 
-Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 1.22). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
+Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 26.2). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
 
 ```json5
 {

--- a/versioned_docs/version-1.21.10/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.10/resources/server/datamaps/builtin.md
@@ -4,7 +4,7 @@ NeoForge provides various built-in [data maps][datamap] for common use cases, re
 
 ## `neoforge:acceptable_villager_distances`
 
-Allows configuring the maximum block distance that villagers will notice an entity, as a replacement for `VillagerHostilesSensor.ACCEPTABLE_DISTANCE_FROM_HOSTILES` (which will be ignored in 1.22). This data map is located at `neoforge/data_maps/entity_type/acceptable_villager_distances.json` and its objects have the following structure:
+Allows configuring the maximum block distance that villagers will notice an entity, as a replacement for `VillagerHostilesSensor.ACCEPTABLE_DISTANCE_FROM_HOSTILES` (which will be ignored in 26.2). This data map is located at `neoforge/data_maps/entity_type/acceptable_villager_distances.json` and its objects have the following structure:
 
 ```json5
 {
@@ -202,7 +202,7 @@ Example:
 
 ## `neoforge:strippables`
 
-Allows configuring the block a block will turn into when stripped (right clicked with an axe, or an item with the item ability `ItemAbilities#AXE_STRIP`), as a replacement for `AxeItem#STRIPPABLES` (which will be ignored in 1.22). This data map is located at `neoforge/data_maps/block/strippables.json` and its objects have the following structure:
+Allows configuring the block a block will turn into when stripped (right clicked with an axe, or an item with the item ability `ItemAbilities#AXE_STRIP`), as a replacement for `AxeItem#STRIPPABLES` (which will be ignored in 26.2). This data map is located at `neoforge/data_maps/block/strippables.json` and its objects have the following structure:
 
 ```json5
 {
@@ -250,7 +250,7 @@ Example:
 
 ## `neoforge:villager_types`
 
-Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 1.22). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
+Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 26.2). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
 
 ```json5
 {

--- a/versioned_docs/version-1.21.11/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.11/resources/server/datamaps/builtin.md
@@ -4,7 +4,7 @@ NeoForge provides various built-in [data maps][datamap] for common use cases, re
 
 ## `neoforge:acceptable_villager_distances`
 
-Allows configuring the maximum block distance that villagers will notice an entity, as a replacement for `VillagerHostilesSensor.ACCEPTABLE_DISTANCE_FROM_HOSTILES` (which will be ignored in 1.22). This data map is located at `neoforge/data_maps/entity_type/acceptable_villager_distances.json` and its objects have the following structure:
+Allows configuring the maximum block distance that villagers will notice an entity, as a replacement for `VillagerHostilesSensor.ACCEPTABLE_DISTANCE_FROM_HOSTILES` (which will be ignored in 26.2). This data map is located at `neoforge/data_maps/entity_type/acceptable_villager_distances.json` and its objects have the following structure:
 
 ```json5
 {
@@ -202,7 +202,7 @@ Example:
 
 ## `neoforge:strippables`
 
-Allows configuring the block a block will turn into when stripped (right clicked with an axe, or an item with the item ability `ItemAbilities#AXE_STRIP`), as a replacement for `AxeItem#STRIPPABLES` (which will be ignored in 1.22). This data map is located at `neoforge/data_maps/block/strippables.json` and its objects have the following structure:
+Allows configuring the block a block will turn into when stripped (right clicked with an axe, or an item with the item ability `ItemAbilities#AXE_STRIP`), as a replacement for `AxeItem#STRIPPABLES` (which will be ignored in 26.2). This data map is located at `neoforge/data_maps/block/strippables.json` and its objects have the following structure:
 
 ```json5
 {
@@ -250,7 +250,7 @@ Example:
 
 ## `neoforge:villager_types`
 
-Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 1.22). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
+Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 26.2). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
 
 ```json5
 {

--- a/versioned_docs/version-1.21.3/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.3/resources/server/datamaps/builtin.md
@@ -202,7 +202,7 @@ Example:
 
 ## `neoforge:villager_types`
 
-Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 1.22). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
+Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 26.2). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
 
 ```json5
 {

--- a/versioned_docs/version-1.21.4/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.4/resources/server/datamaps/builtin.md
@@ -202,7 +202,7 @@ Example:
 
 ## `neoforge:villager_types`
 
-Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 1.22). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
+Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 26.2). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
 
 ```json5
 {

--- a/versioned_docs/version-1.21.5/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.5/resources/server/datamaps/builtin.md
@@ -202,7 +202,7 @@ Example:
 
 ## `neoforge:villager_types`
 
-Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 1.22). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
+Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 26.2). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
 
 ```json5
 {

--- a/versioned_docs/version-1.21.8/resources/server/datamaps/builtin.md
+++ b/versioned_docs/version-1.21.8/resources/server/datamaps/builtin.md
@@ -4,7 +4,7 @@ NeoForge provides various built-in [data maps][datamap] for common use cases, re
 
 ## `neoforge:acceptable_villager_distances`
 
-Allows configuring the maximum block distance that villagers will notice an entity, as a replacement for `VillagerHostilesSensor.ACCEPTABLE_DISTANCE_FROM_HOSTILES` (which will be ignored in 1.22). This data map is located at `neoforge/data_maps/entity_type/acceptable_villager_distances.json` and its objects have the following structure:
+Allows configuring the maximum block distance that villagers will notice an entity, as a replacement for `VillagerHostilesSensor.ACCEPTABLE_DISTANCE_FROM_HOSTILES` (which will be ignored in 26.2). This data map is located at `neoforge/data_maps/entity_type/acceptable_villager_distances.json` and its objects have the following structure:
 
 ```json5
 {
@@ -226,7 +226,7 @@ Example:
 
 ## `neoforge:villager_types`
 
-Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 1.22). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
+Allows configuring the villager type that will spawn based on its biome, as a replacement for `VillagerType#BY_BIOME` (which will be ignored in 26.2). It is located at `neoforge/data_maps/worldgen/biome/villager_types.json` and its objects have the following structure:
 
 ```json5
 {


### PR DESCRIPTION
Closes #345 

Replaces the `1.22` ignore versions within the built-in datamaps with the next release `26.2`.

------------------
Preview URL: https://pr-346.neoforged-docs-previews.pages.dev