### PR TITLE
Remove redundant stack count check

### DIFF
--- a/docs/inventories/menus.md
+++ b/docs/inventories/menus.md
@@ -315,16 +315,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
             quickMovedSlot.setChanged();
         }
 
-        /*
-        The following if statement and Slot#onTake call can be removed if the
-        menu does not represent a container that can transform stacks (e.g.
-        chests).
-        */
-        if (rawStack.getCount() == quickMovedStack.getCount()) {
-            // If the raw stack was not able to be moved to another slot, no longer quick move
-            return ItemStack.EMPTY;
-        }
         // Execute logic on what to do post move with the remaining stack
+        // This can be removed if there are no `Slot` subtypes that override `onTake`
         quickMovedSlot.onTake(player, rawStack);
     }
 

--- a/versioned_docs/version-1.20.4/gui/menus.md
+++ b/versioned_docs/version-1.20.4/gui/menus.md
@@ -202,7 +202,7 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
     The following quick move logic can be simplified to if in data inventory,
     try to move to player inventory/hotbar and vice versa for containers
     that cannot transform data (e.g. chests).
-    -/
+    */
 
     // If the quick move was performed on the data inventory result slot
     if (quickMovedSlotIndex == 0) {
@@ -247,16 +247,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
       quickMovedSlot.setChanged();
     }
 
-    /*
-    The following if statement and Slot#onTake call can be removed if the
-    menu does not represent a container that can transform stacks (e.g.
-    chests).
-    -/
-    if (rawStack.getCount() == quickMovedStack.getCount()) {
-      // If the raw stack was not able to be moved to another slot, no longer quick move
-      return ItemStack.EMPTY;
-    }
     // Execute logic on what to do post move with the remaining stack
+    // This can be removed if there are no `Slot` subtypes that override `onTake`
     quickMovedSlot.onTake(player, rawStack);
   }
 

--- a/versioned_docs/version-1.20.6/gui/menus.md
+++ b/versioned_docs/version-1.20.6/gui/menus.md
@@ -245,16 +245,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
       quickMovedSlot.setChanged();
     }
 
-    /*
-    The following if statement and Slot#onTake call can be removed if the
-    menu does not represent a container that can transform stacks (e.g.
-    chests).
-    */
-    if (rawStack.getCount() == quickMovedStack.getCount()) {
-      // If the raw stack was not able to be moved to another slot, no longer quick move
-      return ItemStack.EMPTY;
-    }
     // Execute logic on what to do post move with the remaining stack
+    // This can be removed if there are no `Slot` subtypes that override `onTake`
     quickMovedSlot.onTake(player, rawStack);
   }
 

--- a/versioned_docs/version-1.21.1/gui/menus.md
+++ b/versioned_docs/version-1.21.1/gui/menus.md
@@ -245,16 +245,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
             quickMovedSlot.setChanged();
         }
 
-        /*
-        The following if statement and Slot#onTake call can be removed if the
-        menu does not represent a container that can transform stacks (e.g.
-        chests).
-        */
-        if (rawStack.getCount() == quickMovedStack.getCount()) {
-            // If the raw stack was not able to be moved to another slot, no longer quick move
-            return ItemStack.EMPTY;
-        }
         // Execute logic on what to do post move with the remaining stack
+        // This can be removed if there are no `Slot` subtypes that override `onTake`
         quickMovedSlot.onTake(player, rawStack);
     }
 

--- a/versioned_docs/version-1.21.10/inventories/menus.md
+++ b/versioned_docs/version-1.21.10/inventories/menus.md
@@ -315,16 +315,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
             quickMovedSlot.setChanged();
         }
 
-        /*
-        The following if statement and Slot#onTake call can be removed if the
-        menu does not represent a container that can transform stacks (e.g.
-        chests).
-        */
-        if (rawStack.getCount() == quickMovedStack.getCount()) {
-            // If the raw stack was not able to be moved to another slot, no longer quick move
-            return ItemStack.EMPTY;
-        }
         // Execute logic on what to do post move with the remaining stack
+        // This can be removed if there are no `Slot` subtypes that override `onTake`
         quickMovedSlot.onTake(player, rawStack);
     }
 

--- a/versioned_docs/version-1.21.11/inventories/menus.md
+++ b/versioned_docs/version-1.21.11/inventories/menus.md
@@ -315,16 +315,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
             quickMovedSlot.setChanged();
         }
 
-        /*
-        The following if statement and Slot#onTake call can be removed if the
-        menu does not represent a container that can transform stacks (e.g.
-        chests).
-        */
-        if (rawStack.getCount() == quickMovedStack.getCount()) {
-            // If the raw stack was not able to be moved to another slot, no longer quick move
-            return ItemStack.EMPTY;
-        }
         // Execute logic on what to do post move with the remaining stack
+        // This can be removed if there are no `Slot` subtypes that override `onTake`
         quickMovedSlot.onTake(player, rawStack);
     }
 

--- a/versioned_docs/version-1.21.3/gui/menus.md
+++ b/versioned_docs/version-1.21.3/gui/menus.md
@@ -249,16 +249,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
             quickMovedSlot.setChanged();
         }
 
-        /*
-        The following if statement and Slot#onTake call can be removed if the
-        menu does not represent a container that can transform stacks (e.g.
-        chests).
-        */
-        if (rawStack.getCount() == quickMovedStack.getCount()) {
-            // If the raw stack was not able to be moved to another slot, no longer quick move
-            return ItemStack.EMPTY;
-        }
         // Execute logic on what to do post move with the remaining stack
+        // This can be removed if there are no `Slot` subtypes that override `onTake`
         quickMovedSlot.onTake(player, rawStack);
     }
 

--- a/versioned_docs/version-1.21.4/gui/menus.md
+++ b/versioned_docs/version-1.21.4/gui/menus.md
@@ -249,16 +249,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
             quickMovedSlot.setChanged();
         }
 
-        /*
-        The following if statement and Slot#onTake call can be removed if the
-        menu does not represent a container that can transform stacks (e.g.
-        chests).
-        */
-        if (rawStack.getCount() == quickMovedStack.getCount()) {
-            // If the raw stack was not able to be moved to another slot, no longer quick move
-            return ItemStack.EMPTY;
-        }
         // Execute logic on what to do post move with the remaining stack
+        // This can be removed if there are no `Slot` subtypes that override `onTake`
         quickMovedSlot.onTake(player, rawStack);
     }
 

--- a/versioned_docs/version-1.21.5/gui/menus.md
+++ b/versioned_docs/version-1.21.5/gui/menus.md
@@ -249,16 +249,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
             quickMovedSlot.setChanged();
         }
 
-        /*
-        The following if statement and Slot#onTake call can be removed if the
-        menu does not represent a container that can transform stacks (e.g.
-        chests).
-        */
-        if (rawStack.getCount() == quickMovedStack.getCount()) {
-            // If the raw stack was not able to be moved to another slot, no longer quick move
-            return ItemStack.EMPTY;
-        }
         // Execute logic on what to do post move with the remaining stack
+        // This can be removed if there are no `Slot` subtypes that override `onTake`
         quickMovedSlot.onTake(player, rawStack);
     }
 

--- a/versioned_docs/version-1.21.8/gui/menus.md
+++ b/versioned_docs/version-1.21.8/gui/menus.md
@@ -310,16 +310,8 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
             quickMovedSlot.setChanged();
         }
 
-        /*
-        The following if statement and Slot#onTake call can be removed if the
-        menu does not represent a container that can transform stacks (e.g.
-        chests).
-        */
-        if (rawStack.getCount() == quickMovedStack.getCount()) {
-            // If the raw stack was not able to be moved to another slot, no longer quick move
-            return ItemStack.EMPTY;
-        }
         // Execute logic on what to do post move with the remaining stack
+        // This can be removed if there are no `Slot` subtypes that override `onTake`
         quickMovedSlot.onTake(player, rawStack);
     }
 


### PR DESCRIPTION
Removes:
```
if (rawStack.getCount() == quickMovedStack.getCount()) {
    // If the raw stack was not able to be moved to another slot, no longer quick move
    return ItemStack.EMPTY;
}
```

From the `AbstractContainerMenu#quickMoveStack` example as the if statement will always be false. It originally had a purpose back in b1.6, but another fix in b1.8.1 made the statement redundant.

Thanks to @celdaemon bringing up the discrepancy and investigating with me.

------------------
Preview URL: https://pr-348.neoforged-docs-previews.pages.dev