### PR TITLE
[21.5-26.1] Fix `RegisterGameTestsEvent` example

### DIFF
--- a/docs/misc/gametest.md
+++ b/docs/misc/gametest.md
@@ -1002,7 +1002,7 @@ public static void registerTests(RegisterGameTestsEvent event) {
             0,
             true,
             new TestData<>(
-                environments.getOrThrow(EXAMPLE_ENVIRONMENT),
+                environment,
                 Identifier.fromNamespaceAndPath("examplemod", "example_structure"),
                 400,
                 50,

--- a/versioned_docs/version-1.21.10/misc/gametest.md
+++ b/versioned_docs/version-1.21.10/misc/gametest.md
@@ -975,7 +975,7 @@ public static void registerTests(RegisterGameTestsEvent event) {
             0,
             true,
             new TestData<>(
-                environments.getOrThrow(EXAMPLE_ENVIRONMENT),
+                environment,
                 ResourceLocation.fromNamespaceAndPath("examplemod", "example_structure"),
                 400,
                 50,

--- a/versioned_docs/version-1.21.11/misc/gametest.md
+++ b/versioned_docs/version-1.21.11/misc/gametest.md
@@ -949,7 +949,7 @@ public static void registerTests(RegisterGameTestsEvent event) {
             0,
             true,
             new TestData<>(
-                environments.getOrThrow(EXAMPLE_ENVIRONMENT),
+                environment,
                 Identifier.fromNamespaceAndPath("examplemod", "example_structure"),
                 400,
                 50,

--- a/versioned_docs/version-1.21.5/misc/gametest.md
+++ b/versioned_docs/version-1.21.5/misc/gametest.md
@@ -975,7 +975,7 @@ public static void registerTests(RegisterGameTestsEvent event) {
             0,
             true,
             new TestData<>(
-                environments.getOrThrow(EXAMPLE_ENVIRONMENT),
+                environment,
                 ResourceLocation.fromNamespaceAndPath("examplemod", "example_structure"),
                 400,
                 50,

--- a/versioned_docs/version-1.21.8/misc/gametest.md
+++ b/versioned_docs/version-1.21.8/misc/gametest.md
@@ -975,7 +975,7 @@ public static void registerTests(RegisterGameTestsEvent event) {
             0,
             true,
             new TestData<>(
-                environments.getOrThrow(EXAMPLE_ENVIRONMENT),
+                environment,
                 ResourceLocation.fromNamespaceAndPath("examplemod", "example_structure"),
                 400,
                 50,


### PR DESCRIPTION
Bad copy-pasta as the environment is now available inside the event itself rather than having to obtain through a registry lookup.

------------------
Preview URL: https://pr-352.neoforged-docs-previews.pages.dev