### PR TITLE
[21.1-26.1] Fix `LootTableSubProvider#generate` example

### DIFF
--- a/docs/resources/server/loottables/index.md
+++ b/docs/resources/server/loottables/index.md
@@ -299,9 +299,14 @@ public class MyLootTableSubProvider implements LootTableSubProvider {
     }
 
     @Override
-    public void generate(BiConsumer<Identifier, LootTable.Builder> consumer) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
         // LootTable.lootTable() returns a loot table builder we can add loot tables to.
-        consumer.accept(Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table"), LootTable.lootTable()
+        consumer.accept(
+                ResourceKey.create(
+                    Registries.LOOT_TABLE,
+                    Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table")
+                ),
+                LootTable.lootTable()
                 // Add a loot table-level loot function. This example uses a number provider (see below).
                 .apply(SetItemCountFunction.setCount(ConstantValue.exactly(5)))
                 // Add a loot pool.

--- a/versioned_docs/version-1.21.1/resources/server/loottables/index.md
+++ b/versioned_docs/version-1.21.1/resources/server/loottables/index.md
@@ -285,9 +285,14 @@ public class MyLootTableSubProvider implements LootTableSubProvider {
     }
 
     @Override
-    public void generate(BiConsumer<ResourceLocation, LootTable.Builder> consumer) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
         // LootTable.lootTable() returns a loot table builder we can add loot tables to.
-        consumer.accept(ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table"), LootTable.lootTable()
+        consumer.accept(
+                ResourceKey.create(
+                    Registries.LOOT_TABLE,
+                    ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table")
+                ),
+                LootTable.lootTable()
                 // Add a loot table-level loot function. This example uses a number provider (see below).
                 .apply(SetItemCountFunction.setCount(ConstantValue.exactly(5)))
                 // Add a loot pool.

--- a/versioned_docs/version-1.21.10/resources/server/loottables/index.md
+++ b/versioned_docs/version-1.21.10/resources/server/loottables/index.md
@@ -292,9 +292,14 @@ public class MyLootTableSubProvider implements LootTableSubProvider {
     }
 
     @Override
-    public void generate(BiConsumer<ResourceLocation, LootTable.Builder> consumer) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
         // LootTable.lootTable() returns a loot table builder we can add loot tables to.
-        consumer.accept(ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table"), LootTable.lootTable()
+        consumer.accept(
+                ResourceKey.create(
+                    Registries.LOOT_TABLE,
+                    ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table")
+                ),
+                LootTable.lootTable()
                 // Add a loot table-level loot function. This example uses a number provider (see below).
                 .apply(SetItemCountFunction.setCount(ConstantValue.exactly(5)))
                 // Add a loot pool.

--- a/versioned_docs/version-1.21.11/resources/server/loottables/index.md
+++ b/versioned_docs/version-1.21.11/resources/server/loottables/index.md
@@ -293,9 +293,14 @@ public class MyLootTableSubProvider implements LootTableSubProvider {
     }
 
     @Override
-    public void generate(BiConsumer<Identifier, LootTable.Builder> consumer) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
         // LootTable.lootTable() returns a loot table builder we can add loot tables to.
-        consumer.accept(Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table"), LootTable.lootTable()
+        consumer.accept(
+                ResourceKey.create(
+                    Registries.LOOT_TABLE,
+                    Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table")
+                ),
+                LootTable.lootTable()
                 // Add a loot table-level loot function. This example uses a number provider (see below).
                 .apply(SetItemCountFunction.setCount(ConstantValue.exactly(5)))
                 // Add a loot pool.

--- a/versioned_docs/version-1.21.3/resources/server/loottables/index.md
+++ b/versioned_docs/version-1.21.3/resources/server/loottables/index.md
@@ -287,9 +287,14 @@ public class MyLootTableSubProvider implements LootTableSubProvider {
     }
 
     @Override
-    public void generate(BiConsumer<ResourceLocation, LootTable.Builder> consumer) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
         // LootTable.lootTable() returns a loot table builder we can add loot tables to.
-        consumer.accept(ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table"), LootTable.lootTable()
+        consumer.accept(
+                ResourceKey.create(
+                    Registries.LOOT_TABLE,
+                    ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table")
+                ),
+                LootTable.lootTable()
                 // Add a loot table-level loot function. This example uses a number provider (see below).
                 .apply(SetItemCountFunction.setCount(ConstantValue.exactly(5)))
                 // Add a loot pool.

--- a/versioned_docs/version-1.21.4/resources/server/loottables/index.md
+++ b/versioned_docs/version-1.21.4/resources/server/loottables/index.md
@@ -286,9 +286,14 @@ public class MyLootTableSubProvider implements LootTableSubProvider {
     }
 
     @Override
-    public void generate(BiConsumer<ResourceLocation, LootTable.Builder> consumer) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
         // LootTable.lootTable() returns a loot table builder we can add loot tables to.
-        consumer.accept(ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table"), LootTable.lootTable()
+        consumer.accept(
+                ResourceKey.create(
+                    Registries.LOOT_TABLE,
+                    ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table")
+                ),
+                LootTable.lootTable()
                 // Add a loot table-level loot function. This example uses a number provider (see below).
                 .apply(SetItemCountFunction.setCount(ConstantValue.exactly(5)))
                 // Add a loot pool.

--- a/versioned_docs/version-1.21.5/resources/server/loottables/index.md
+++ b/versioned_docs/version-1.21.5/resources/server/loottables/index.md
@@ -286,9 +286,14 @@ public class MyLootTableSubProvider implements LootTableSubProvider {
     }
 
     @Override
-    public void generate(BiConsumer<ResourceLocation, LootTable.Builder> consumer) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
         // LootTable.lootTable() returns a loot table builder we can add loot tables to.
-        consumer.accept(ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table"), LootTable.lootTable()
+        consumer.accept(
+                ResourceKey.create(
+                    Registries.LOOT_TABLE,
+                    ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table")
+                ),
+                LootTable.lootTable()
                 // Add a loot table-level loot function. This example uses a number provider (see below).
                 .apply(SetItemCountFunction.setCount(ConstantValue.exactly(5)))
                 // Add a loot pool.

--- a/versioned_docs/version-1.21.8/resources/server/loottables/index.md
+++ b/versioned_docs/version-1.21.8/resources/server/loottables/index.md
@@ -286,9 +286,14 @@ public class MyLootTableSubProvider implements LootTableSubProvider {
     }
 
     @Override
-    public void generate(BiConsumer<ResourceLocation, LootTable.Builder> consumer) {
+    public void generate(BiConsumer<ResourceKey<LootTable>, LootTable.Builder> consumer) {
         // LootTable.lootTable() returns a loot table builder we can add loot tables to.
-        consumer.accept(ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table"), LootTable.lootTable()
+        consumer.accept(
+                ResourceKey.create(
+                    Registries.LOOT_TABLE,
+                    ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_loot_table")
+                ),
+                LootTable.lootTable()
                 // Add a loot table-level loot function. This example uses a number provider (see below).
                 .apply(SetItemCountFunction.setCount(ConstantValue.exactly(5)))
                 // Add a loot pool.


### PR DESCRIPTION
`LootTableSubProvider#generate` has taken in a `ResourceKey<LootTable>` instead of an `Identifier` since 20.6, which surprisingly has the correct method signature. It's likely that the change was missed when datagen was merged into their respective docs rather than having one page for each.

Closes #354 

------------------
Preview URL: https://pr-355.neoforged-docs-previews.pages.dev