### PR TITLE
Fix references to modproperties and features to TOML tables

### DIFF
--- a/docs/gettingstarted/modfiles.md
+++ b/docs/gettingstarted/modfiles.md
@@ -119,7 +119,7 @@ modId = "examplemod2"
 
 #### Features
 
-The features system allows mods to demand that certain settings, software, or hardware are available when loading the system. When a feature is not satisfied, mod loading will fail, informing the user about the requirement. These configurations are created using the [array of tables][array] `[[features.<modid>]]`, where `modid` is the identifier of the mod that consumes the feature. Currently, NeoForge provides the following features:
+The features system allows mods to demand that certain settings, software, or hardware are available when loading the system. When a feature is not satisfied, mod loading will fail, informing the user about the requirement. These configurations are created using a [table] `[features.<modid>]`, where `modid` is the identifier of the mod that consumes the feature. Currently, NeoForge provides the following features:
 
 | Feature          | Description                                                                                                                                                                                                | Example                             |
 |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
@@ -127,13 +127,13 @@ The features system allows mods to demand that certain settings, software, or ha
 
 #### Mod Properties
 
-The mod properties system is a map of arbitrary keys to values that are associated with a particular mod. These can be useful when a mod file defines multiple mods that provide different metadata. From there, the specific property value for some key can be obtained by getting the object value from the map via `IModInfo#getModProperties`. These configurations are created using the [array of tables][array] `[[modproperties.<modid>]]`, where `modid` is the identifier of the mod that consumes the defined properties.
+The mod properties system is a map of arbitrary keys to values that are associated with a particular mod. These can be useful when mod files define identical keys that provide different metadata. From there, the specific property value for some key can be obtained by getting the object value from the map via `IModInfo#getModProperties`. These configurations are created using a [table] `[modproperties.<modid>]`, where `modid` is the identifier of the mod that consumes the defined properties.
 
 ```java
-// Assume we have two mods `mod1` and `mod2` with the following property configuration
-// [[modproperties.mod1]]
+// Assume we have two mods `mod1` and `mod2` with the following property configuration in separate files
+// [modproperties.mod1]
 // key="value1"
-// [[modproperties.mod2]]
+// [modproperties.mod2]
 // key="value2"
 
 @Mod("mod1")
@@ -242,6 +242,7 @@ An entry in `neoforge.mods.toml` does not need a corresponding `@Mod` annotation
 
 [accesstransformer]: ../advanced/accesstransformers.md#adding-ats
 [array]: https://toml.io/en/v1.0.0#array-of-tables
+[table]: https://toml.io/en/v1.0.0#table
 [atlasviewer]: https://github.com/XFactHD/AtlasViewer/blob/1.20.2/neoforge/src/main/resources/META-INF/services/xfacthd.atlasviewer.platform.services.IPlatformHelper
 [events]: ../concepts/events.md
 [features]: #features


### PR DESCRIPTION
Resolves: #365 

Adjusts the text to call out table instead of array-of-tables for the toml definition for features and modproperties in the `neoforge.mods.toml` docs

------------------
Preview URL: https://pr-366.neoforged-docs-previews.pages.dev