### PR TITLE
Reload listeners

### DIFF
--- a/docs/resources/client/_category_.json
+++ b/docs/resources/client/_category_.json
@@ -1,3 +1,4 @@
 {
-    "label": "Client"
+    "label": "Client",
+    "position": 1
 }

--- a/docs/resources/client/particles.md
+++ b/docs/resources/client/particles.md
@@ -122,7 +122,7 @@ A particle description looks something like this:
 }
 ```
 
-During resource reload, the `ParticleResources` loads all particle descriptions and stitches the textures into the `TextureAtlas#LOCATION_PARTICLES` atlas. Then, a `SpriteSet` is created for each description, containing a list of the specified `TextureAtlasSprite`s.
+During [resource reload][reload], the `ParticleResources` loads all particle descriptions and stitches the textures into the `TextureAtlas#LOCATION_PARTICLES` atlas. Then, a `SpriteSet` is created for each description, containing a list of the specified `TextureAtlasSprite`s.
 
 ### Using the Description
 
@@ -215,4 +215,5 @@ As a reminder from before, the server only knows [`ParticleType`s][particletype]
 [particle]: ../../rendering/particles.md
 [particletype]: #registering-particletypes
 [provider]: ../../rendering/particles.md#particleprovider
+[reload]: ../reloadlisteners.md#reloading
 [side]: ../../concepts/sides.md

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 0
+---
 # Resources
 
 Resources are external files that are used by the game, but are not code. The most prominent kinds of resources are textures, however, many other types of resources exist in the Minecraft ecosystem. Of course, all these resources require a consumer on the code side, so the consuming systems are grouped in this section as well.

--- a/docs/resources/reloadlisteners.md
+++ b/docs/resources/reloadlisteners.md
@@ -3,13 +3,13 @@ sidebar_position: 3
 ---
 # Reload Listeners
 
-In some situations, integrating with the existing resource systems provided by Minecraft or NeoForge just isn't going to cut it. Instead, having your system load files by itself from a resource or data pack is more desirable. For this purpose, you can register a custom reload listener, implementing `PreparableReloadListener` or one of its subinterfaces/subclasses.
+In some situations, integrating with the [existing resource systems][resources] provided by Minecraft or NeoForge just isn't going to cut it. Instead, having your system load files by itself from a resource or data pack is more desirable. For this purpose, you can register a custom reload listener, implementing `PreparableReloadListener` or one of its subinterfaces/subclasses.
 
 The idea behind a reload listener is simple: When a resource pack or data pack reload happens, the listener is called upon to read its contents from the new set of resource or data packs. It will then keep the contents until the next reload, at which point the contents will be discarded and the cycle starts anew.
 
 ## Reloading
 
-Both resource pack and data pack reload function similar in principle, and only differ in timing and the location files are loaded from.
+Both resource pack and data pack reload function similar in principle and only differ in the associated [side][sides], and by extension the timing and the location files are loaded from.
 
 Client reload listeners load from resource packs (the `assets` folder). The first reload happens during startup on the physical client, and **never** on the physical server. Subsequent reloads are triggered when resource packs are changed in the Options menu, or by pressing F3+T.
 
@@ -23,7 +23,7 @@ Reloading happens on multiple threads, as reload listeners are unrelated to one 
 
 ## Adding a Reload Listener
 
-All reload listeners are registered using the same basic principle. First, we need a reload listener instance. Vanilla typically stores its reload listeners, such as the texture or recipe managers, as fields in `Minecraft` (for client-side listeners) or `ServerLevel` (for server-side listeners), however in modded contexts, a singleton instance is usually fine as well:
+All reload listeners are registered using the same basic principle. First, we need a reload listener instance. Vanilla typically stores its reload listeners, such as the [texture][textures] or [recipe managers][recipes], as fields in `Minecraft` (for client-side listeners) or `ServerLevel` (for server-side listeners), however in modded contexts, a singleton instance is usually fine as well:
 
 ```java
 // Instead of PreparableReloadListener, extend one of its subclasses if applicable, see below.
@@ -40,7 +40,7 @@ public class MyReloadListener implements PreparableReloadListener {
 }
 ```
 
-Then, depending on whether the reload listener is for client data (resource packs) or server data (data packs), the listener is registered to one of two events:
+Then, depending on whether the reload listener is for client data (resource packs) or server data (data packs), the listener is registered to one of two [events][events]:
 
 ```java
 // For client-side reload listeners
@@ -57,7 +57,7 @@ public static void addServerReloadListeners(AddServerReloadListenersEvent event)
 ```
 
 :::danger
-Do not register the same reload listener on both sides! All of your file-driven systems should be designed for one side only, otherwise behavior might differ between singleplayer and multiplayer.
+Do not register the same reload listener on both sides! All of your file-driven systems should be designed for one side only, otherwise desyncs and similar issues will arise.
 :::
 
 And then, the reload listener can be accessed - from the correct side - through the singleton `INSTANCE`.
@@ -112,7 +112,7 @@ And then simply access your values like so:
 MyObject myObject = MyReloadListener.INSTANCE.get(Identifier.fromNamespaceAndPath("mymod", "example"));
 ```
 
-Note that `SimpleJsonResourceReloadListener` goes through the resource packs top to bottom, and only retains the top-most entry for each filename. If you wish to perform merging (similar to e.g. tags) or other operations that involve all the files for each filename from different resource/data packs, see the next section.
+Note that `SimpleJsonResourceReloadListener` goes through the resource packs top to bottom, and only retains the top-most entry for each filename. If you wish to perform merging (similar to e.g. [tags][tags]) or other operations that involve all the files for each filename from different resource/data packs, see the next section.
 
 ### `SimplePreparableReloadListener`
 
@@ -120,7 +120,7 @@ Note that `SimpleJsonResourceReloadListener` goes through the resource packs top
 
 `SimplePreparableReloadListener<T>` splits its reload into two distinct cycles: `prepare` and `apply`. First, `prepare` is called to collect the files and convert them into `T`s. Once **all** files have been collected, `apply` is called to do something with them - usually store them for later use.
 
-For a simple reference implementation of `SimplePreparableReloadListener` that loads from a single file, see `SplashManager`. For an implementation for merging JSON files, see `SoundManager#prepare`, `SoundManager#apply` and the related fields in `SoundManager`.
+For a simple reference implementation of `SimplePreparableReloadListener` that loads from a single file, see `SplashManager`. For an implementation for merging JSON files, see the merging of [`sounds.json`][soundsjson] in `SoundManager#prepare`, `SoundManager#apply` and the related fields in `SoundManager`.
 
 ### `ContextAwareReloadListener`
 
@@ -133,3 +133,11 @@ TODO
 ## `FileToIdConverter`
 
 TODO
+
+[events]: ../concepts/events.md
+[recipes]: server/recipes/index.md
+[resources]: index.md
+[sides]: ../concepts/sides.md
+[soundsjson]: client/sounds.md#soundsjson
+[tags]: server/tags.md
+[textures]: client/textures.md

--- a/docs/resources/reloadlisteners.md
+++ b/docs/resources/reloadlisteners.md
@@ -5,21 +5,28 @@ sidebar_position: 3
 
 In some situations, integrating with the [existing resource systems][resources] provided by Minecraft or NeoForge just isn't going to cut it. Instead, having your system load files by itself from a resource or data pack is more desirable. For this purpose, you can register a custom reload listener, implementing `PreparableReloadListener` or one of its subinterfaces/subclasses.
 
-The idea behind a reload listener is simple: When a resource pack or data pack reload happens, the listener is called upon to read its contents from the new set of resource or data packs, loaded into a global `ResourceManager` and usually reference-copied into other places for easier access. It will then keep the contents until the next reload, at which point the contents will be discarded and the cycle starts anew.
+The idea behind a reload listener is simple: When a resource pack or data pack reload happens, the listener is called upon to read its contents from the new set of resource or data packs. It will then keep the contents until the next reload, at which point the contents will be discarded and the cycle starts anew.
+
+:::info
+On the server [side][sides], the more robust [datapack registry][datapackregistries] or [data map][datamaps] systems should be preferred over a reload listener, if possible.
+:::
 
 ## Reloading
 
-Both resource pack and data pack reload function similar in principle and only differ in the associated [side][sides], and by extension the timing and the location files are loaded from.
+Both resource pack and data pack reload function similar in principle and only differ in the associated physical and logical [side][sides], and by extension the timing and the location files are loaded from.
 
-Client reload listeners load from resource packs (the `assets` folder). The first reload happens during startup on the physical client, and **never** on the physical server. Subsequent reloads are triggered when resource packs are changed in the Options menu, or by pressing F3+T.
+|                                              | Client Reload Listener                                                                                                             | Server Reload Listener                                                                                                |
+|----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| **Loads From**                               | Resource packs (`assets` folder)                                                                                                   | Data packs (`data` folder)                                                                                            |
+| **First Reload**<br/>(Physical Client)       | - Startup                                                                                                                          | - Creating a new world<br/>("Preparing for world creation...")<br/>- Joining an existing world<br/>- Joining a server |
+| **Subsequent Reloads**<br/>(Physical Client) | - Changing resource packs in the Options menu<br/>- Downloading a server's custom resource pack on server join<br/>- Pressing F3+T | - Leaving a world or server<br/>(unloads the listener)                                                                |
+| **First Reload**<br/>(Physical Server)       | _never_                                                                                                                            | - Startup                                                                                                             |
+| **Subsequent Reloads**<br/>(Physical Server) | _never_                                                                                                                            | - `/reload` command                                                                                                   |
 
-Server reload listeners load from data packs (the `data` folder). The first reload happens during world loading, which happens on world/server join on the physical client, and on startup on the physical server. Subsequent reloads are triggered using the `/reload` command, or by switching worlds/servers on the physical client.
 
 :::info
-The `/reload` command also triggers reloads of some other datapack-driven systems, such as [datapack registries][datapackregistries]; this is by design and cannot be circumvented. Datapack registries are reloaded before reload listeners, meaning you can use their values in your server-side reload listeners if needed.
+The `/reload` command also triggers reloads of some other datapack-driven systems, such as [tags][tags]. This is by design and cannot be circumvented.
 :::
-
-Reloading happens on multiple threads, as reload listeners are unrelated to one another. If you need to access another reload listener's values, consider delaying execution until the first use of your system after the reload has complete, or avoid access altogether.
 
 ## Adding a Reload Listener
 
@@ -58,6 +65,8 @@ public static void addServerReloadListeners(AddServerReloadListenersEvent event)
 
 :::danger
 Do not register the same reload listener on both sides! All of your file-driven systems should be designed for one side only, otherwise desyncs and similar issues will arise.
+
+Also, since servers sync their reload listener data to the client, make sure the client implementation either properly clears out those values on disconnect, or never uses them in contexts without a server.
 :::
 
 And then, the reload listener can be accessed - from the correct side - through the singleton `INSTANCE`.
@@ -117,7 +126,7 @@ public class MyReloadListener extends SimpleJsonResourceReloadListener<MyObject>
 }
 ```
 
-And then simply access your values like so:
+And then simply access your values like so (of course making sure that key actually exists):
 
 ```java
 MyObject myObject = MyReloadListener.INSTANCE.get(Identifier.fromNamespaceAndPath("mymod", "example"));
@@ -141,7 +150,7 @@ The above converter will convert paths as follows:
 - `assets/mymod/mymod/my_listener/subfolder/example_2.json` -> `mymod:subfolder/example_2`
 - `assets/othermod/mymod/my_listener/example_3.json` -> `othermod:example_3`
 
-Besides `FileToIdConverter#json()`, there is an additional helper `FileToIdConverter#registry()` that accepts a [`ResourceKey<? extends Registry<?>>`][resourcekey] and converts the registry key to a namespace-and-path string, like the ones above.
+Besides the constructor and the `FileToIdConverter#json()` helper, there is an additional helper `FileToIdConverter#registry()` that accepts a [`ResourceKey<? extends Registry<?>>`][resourcekey] and converts the registry key to a namespace-and-path string, like the ones above.
 
 :::tip
 In order to avoid conflicts where two mods add a registry that is named the same, it is strongly recommended to prefix your reload listener's folder with a folder named after the mod id, as seen above with `mymod/my_listener`.
@@ -167,12 +176,42 @@ Outside the class hierarchy described so far, `ResourceManagerReloadListener` is
 
 Finally, `PreparableReloadListener` sits at the top of the hierarchy, and is the type accepted by the events above. It defines a method `#reload()` that returns a `CompletableFuture<Void>` and accepts four parameters:
 
-- `PreparableReloadListener.SharedState currentReload`: This holds the "global state" of the reload, most notably including the partially-initialized `ResourceManager`.
+- `SharedState currentReload`: This holds the shared state of the reload, see below.
 - `Executor taskExecutor`: The `Executor` for the bulk of the tasks. This executor runs on multiple threads.
-- `PreparableReloadListener.PreparationBarrier barrier`: A threading barrier object. When creating a `CompletableFuture` yourself, a call to `thenCompose(barrier::wait)` should be added to make sure all the `CompletableFuture`s have caught up. See vanilla uses of `barrier#wait()` for reference.
+- `PreparationBarrier barrier`: A threading barrier object. When creating a `CompletableFuture` yourself, a call to `thenCompose(barrier::wait)` should be added to make sure all the `CompletableFuture`s have caught up. See vanilla uses of `barrier#wait()` for reference.
 - `Executor reloadExecutor`: The `Executor` for tasks that need to run on the main tasks. Called the reload executor as commonly those are tasks towards the end of the reload.
 
 You can load basically anything here. For example, this is used by many reload listeners that load binary data ([textures][textures], fonts, etc., but not [sounds][sounds]), as well as some others such as [data maps][datamaps].
+
+## Shared Reloading State
+
+Reloading happens on multiple threads, as reload listeners are generally unrelated to one another. If you need to access another reload listener's values, you must set a shared state. To do so, in your reload listener, override the default `prepareSharedState()` method:
+
+```java
+// Create a record (or class) holding our data to pass to another listener
+public record MyPendingResources(/* any data here */) {}
+
+// Can also extend/implement any subclass/subinterface of PreparableReloadListener
+public class MyReloadListener implements PreparableReloadListener {
+    // other stuff here
+
+    // Create a StateKey with our record as the type
+    public static final StateKey<MyPendingResources> STATE_KEY = new StateKey<>();
+    
+    // Override prepareSharedState() to add our pending resources
+    @Override
+    public void prepareSharedState(PreparableReloadListener.SharedState currentReload) {
+        currentReload.set(STATE_KEY, new MyPendingResources(/* any data here */));
+    }
+
+    // Then, use in reload() like so:
+    @Override
+    public CompletableFuture<Void> reload(SharedState currentReload, Executor taskExecutor, PreparationBarrier barrier, Executor reloadExecutor) {
+        MyPendingResources pending = currentReload.get(STATE_KEY);
+        // do the reload here, using `pending`
+    }
+}
+```
 
 [conditions]: server/conditions.md
 [datamaps]: server/datamaps/index.md

--- a/docs/resources/reloadlisteners.md
+++ b/docs/resources/reloadlisteners.md
@@ -7,7 +7,7 @@ In some situations, integrating with the [existing resource systems][resources] 
 
 The idea behind a reload listener is simple: When a resource pack or data pack reload happens, the listener is called upon to read its contents from the new set of resource or data packs. It will then keep the contents until the next reload, at which point the contents will be discarded and the cycle starts anew.
 
-:::info
+:::warning
 On the server [side][sides], the more robust [datapack registry][datapackregistries] or [data map][datamaps] systems should be preferred over a reload listener, if possible.
 :::
 
@@ -23,10 +23,40 @@ Both resource pack and data pack reload function similar in principle and only d
 | **First Reload**<br/>(Physical Server)       | _never_                                                                                                                            | - Startup                                                                                                             |
 | **Subsequent Reloads**<br/>(Physical Server) | _never_                                                                                                                            | - `/reload` command                                                                                                   |
 
-
 :::info
 The `/reload` command also triggers reloads of some other datapack-driven systems, such as [tags][tags]. This is by design and cannot be circumvented.
 :::
+
+### Multi-Threaded Reloading
+
+Conceptually, the work of a single reload listener can commonly be split into two stages:
+
+- **Preparation**: The necessary files are collected, validated and parsed into some object that can be used in the next step. The preparation stage is run on **multiple threads**.
+- **Application**: The object from the previous step is "applied" to the game, usually by means of setting some field or adding to some collection. The application stage is run on the **main thread**.
+
+To ensure synchronization, after preparation, a `PreparationBarrier` is `wait`ed for by the underlying `CompletableFuture`. Only once all preparation threads have run, the application is allowed to run. In code, this looks roughly as follows:
+
+```java
+@Override
+public CompletableFuture<Void> reload(
+    SharedState currentReload,
+    Executor taskExecutor,
+    PreparationBarrier barrier,
+    Executor reloadExecutor
+) {
+    return CompletableFuture
+        .supplyAsync(() -> {
+            // Collect and return the result of the preparation stage here.
+        })
+        .thenCompose(barrier::wait)
+        .thenAcceptAsync(preparations -> {
+            // Run the application stage.
+            // `preparations` is the return value of the `supplyAsync` call above.
+        });
+}
+```
+
+See [`PreparableReloadListener`][preparablereloadlistener] below for an explanation of the parameters.
 
 ## Adding a Reload Listener
 
@@ -84,14 +114,75 @@ graph LR;
 
 _Interfaces in green, abstract classes in blue._
 
-All reload listeners implement the `PreparableReloadListener` interface. However, in order to make things more understandable, we will first cover the `SimpleJsonResourceReloadListener`, which is used to load JSON files and implements most things for you already. Then, we will gradually go up the class hierarchy and explain what is done for you and what you can modify yourself in each level.
+### `PreparableReloadListener`
+
+`PreparableReloadListener` sits at the top of the hierarchy, and is the type accepted by the events above. It defines a method `#reload()` that returns a `CompletableFuture<Void>` and accepts four parameters:
+
+- `SharedState currentReload`: The [shared state][sharedstate] of the reload.
+- `Executor taskExecutor`: An `Executor` for tasks that can run on multiple threads.
+- `PreparationBarrier barrier`: A threading barrier object.
+- `Executor reloadExecutor`: An `Executor` for tasks that need to run on the main thread.
+
+Additionally, it defines two default methods:
+
+- `prepareSharedState(SharedState currentReload)`: Does nothing by default. See [Shared Reloading State][sharedstate].
+- `getName()`: Returns a name to use in logging. By default, returns the class name.
+
+In a `PreparableReloadListener`, you can load basically anything here. For example, this is directly implemented by many reload listeners that load binary data ([textures][textures], fonts, etc., but not [sounds][sounds]), as well as some others such as [data maps][datamaps]. However, many systems - for example many JSON-based systems - use one of the abstract classes below instead.
+
+### `ContextAwareReloadListener`
+
+`ContextAwareReloadListener` is a utility class that supplies a [load condition][conditions] context, obtainable via `#getContext()`. Additionally, it provides a registry access via `#getRegistryLookup()`.
+
+:::info
+This class is added into the hierarchy by NeoForge, as load conditions are a NeoForge system.
+:::
+
+### `SimplePreparableReloadListener`
+
+`SimplePreparableReloadListener<T>` is an example implementation of a `PreparableReloadListener` that splits the preparation and application stages (see [Multi-Threaded Reloading][multithreading]) into two entirely separate methods. Instead of `#reload()`, you must now override `#prepare()` and `#apply()`. For example:
+
+```java
+// The generic type denotes the type of the object that is passed from #prepare() to #apply().
+// For example, in many cases, this will be a List<MyObject>, Map<?, MyObject> or similar.
+// This is often (but not necessarily) the same as the type of the stored data.
+public class MyReloadListener extends SimplePreparableReloadListener<MyObject> {
+    // As above.
+    public static final Identifier ID = Identifier.fromNamespaceAndPath("mymod", "my_listener");
+    public static final MyReloadListener INSTANCE = new MyReloadListener();
+    private MyReloadListener() {}
+
+    // A field to hold our object.
+    private MyObject myObject;
+
+    @Override    
+    protected MyObject prepare(ResourceManager manager, ProfilerFiller profiler) {
+        // Run whatever logic to collect, parse and validate the files.
+        return new MyObject();
+    }
+
+    @Override
+    protected void apply(MyObject preparations, ResourceManager manager, ProfilerFiller profiler) {
+        // Set the field in our object to the prepared objects, for later use.
+        this.myObject = preparations;
+    }
+
+    // Provide access to the values in whatever way you deem necessary. For example:
+    public MyObject getMyObject() {
+        return myObject;
+    }
+}
+```
 
 ### `SimpleJsonResourceReloadListener`
 
-`SimpleJsonResourceReloadListener<T>` is what you want to use for loading most JSON files. It scans a certain folder for JSON files, converts the contents into objects according to the provided codec, puts the filenames and associated objects into a `Map<Identifier, T>`, and provides that map to you in `#apply()`. The simplest implementation looks like this:
+`SimpleJsonResourceReloadListener<T>` is a further specialization of `SimplePreparableReloadListener` that loads and parses JSON files using a [`Codec`][codec]. It extends `SimplePreparableReloadListener<Map<Identifier, T>>`, meaning a map of filenames (represented as [identifiers][identifier]) to whatever type you want to parse your JSONs to.
+
+The class also completely implements the preparation stage for you, in the manner that most JSON systems work: going through the resource packs top to bottom, and only retains the top-most entry for each filename. This means that to perform merging (similar to e.g. [tags][tags]) or other operations that involve all the files for each filename from different resource/data packs, you need to implement folder scanning yourself.
+
+All that remains for you to do is store the `Map<Identifier, T>` in `#apply()`. The simplest implementation looks like this:
 
 ```java
-// Assuming a type MyObject, and MyObject.CODEC to be a Codec<MyObject>.
 public class MyReloadListener extends SimpleJsonResourceReloadListener<MyObject> {
     // As above.
     public static final Identifier ID = Identifier.fromNamespaceAndPath("mymod", "my_listener");
@@ -100,18 +191,16 @@ public class MyReloadListener extends SimpleJsonResourceReloadListener<MyObject>
     private final Map<Identifier, MyObject> values = new HashMap<>();
 
     private MyReloadListener() {
-        // Add a super call here. The parameters are the codec
+        // Add a super call here. The parameters are the codec (assuming MyObject.CODEC to be a Codec<MyObject>)
         // and a FileToIdConverter, see the FileToIdConverter section below.
         super(MyObject.CODEC, FileToIdConverter.json("mymod/my_listener"));
     }
 
     @Override
-    protected void apply(Map<Identifier, MyObject> map, ResourceManager resourceManager, ProfilerFiller profiler) {
-        // Clear out the old values.
+    protected void apply(Map<Identifier, MyObject> preparations, ResourceManager resourceManager, ProfilerFiller profiler) {
+        // Clear out the old values and add our new ones.
         values.clear();
-        // In the most simple implementation, blindly add all the values we get into the map.
-        // If needed, you can perform validations, duplicate removal or similar here.
-        values.putAll(map);
+        values.putAll(preparations);
     }
 
     // Provide access to the values in whatever way you deem necessary. For example:
@@ -132,60 +221,50 @@ And then simply access your values like so (of course making sure that key actua
 MyObject myObject = MyReloadListener.INSTANCE.get(Identifier.fromNamespaceAndPath("mymod", "example"));
 ```
 
-Note that `SimpleJsonResourceReloadListener` goes through the resource packs top to bottom, and only retains the top-most entry for each filename. If you wish to perform merging (similar to e.g. [tags][tags]) or other operations that involve all the files for each filename from different resource/data packs, use a [`SimplePreparableReloadListener`][simplepreparablereloadlistener] instead.
-
 #### `FileToIdConverter`
 
-`FileToIdConverter` is a utility record used for converting filenames into [`Identifier`s][identifier]. It defines a namespace-local prefix and an extension, which are stripped away. For example:
+`FileToIdConverter` is a utility record used for converting filenames into [`Identifier`s][identifier]. It defines a namespace-local prefix and an extension, which are stripped away. According to these, the converter splits each file path into five parts:
+
+- The `assets` or `data` directory
+- The namespace, consisting of the next subdirectory's name
+- The prefix of the `FileToIdConverter` (which may contain slashes, making it span multiple directory layers)
+- The path of the file (which again may contain slashes to span multiple directory layers)
+- The extension of the file.
+
+It will then construct an `Identifier` from the namespace and the path of the file, i.e., the second and fourth part. For example, consider the following `FileToIdConverter`:
 
 ```java
 FileToIdConverter converter = new FileToIdConverter("mymod/my_listener", ".json");
-// Equivalent:
+// Equivalent, automatically sets the .json extension:
 FileToIdConverter converter = FileToIdConverter.json("mymod/my_listener");
 ```
 
-The above converter will convert paths as follows:
+The above converter will split the path `assets/mymod/mymod/my_listener/example_1.json` as follows:
 
-- `assets/mymod/mymod/my_listener/example_1.json` -> `mymod:example_1`
+- `assets`
+- `mymod` is the namespace
+- `mymod/my_listener` is the prefix of the `FileToIdConverter`
+- `example_1` is the path
+- `.json` is the extension of the `FileToIdConverter`
+
+So the resulting `Identifier` will be `mymod:example_1`. Other examples:
+
 - `assets/mymod/mymod/my_listener/subfolder/example_2.json` -> `mymod:subfolder/example_2`
 - `assets/othermod/mymod/my_listener/example_3.json` -> `othermod:example_3`
 
 Besides the constructor and the `FileToIdConverter#json()` helper, there is an additional helper `FileToIdConverter#registry()` that accepts a [`ResourceKey<? extends Registry<?>>`][resourcekey] and converts the registry key to a namespace-and-path string, like the ones above.
 
 :::tip
-In order to avoid conflicts where two mods add a registry that is named the same, it is strongly recommended to prefix your reload listener's folder with a folder named after the mod id, as seen above with `mymod/my_listener`.
+In order to avoid conflicts where two mods add a registry that is named the same, it is strongly recommended to prefix your reload listener's folder with a folder named after the mod id, as seen above with `mymod/my_listener`. The `#registry()` helper does this for you automatically.
 :::
-
-### `SimplePreparableReloadListener`
-
-`SimplePreparableReloadListener<T>` sits a layer above `SimpleJsonResourceReloadListener<T>`, and is also usable for non-JSON files, as well as (JSON or non-JSON) files with the same name from different resource/data packs.
-
-`SimplePreparableReloadListener<T>` splits its reload into two distinct cycles: `prepare` and `apply`. First, `prepare` is called to collect the files and convert them into `T`s. Once **all** files have been collected, `apply` is called to do something with them - usually store them for later use.
-
-For a simple reference implementation of `SimplePreparableReloadListener` that loads from a single file, see `SplashManager`. For an implementation for merging JSON files, see the merging of [`sounds.json`][soundsjson] in `SoundManager#prepare()`, `SoundManager#apply()` and the related fields in `SoundManager`. For an implementation of folder scanning, see `SimpleJsonResourceReloadListener#prepare()`.
-
-### `ContextAwareReloadListener`
-
-Next up in the hierarchy is `ContextAwareReloadListener`. This is a utility class added into the hierarchy by NeoForge in order to supply a [load condition][conditions] context, obtainable via `#getContext()`. Additionally, it provides a registry access via `#getRegistryLookup()`.
 
 ### `ResourceManagerReloadListener`
 
-Outside the class hierarchy described so far, `ResourceManagerReloadListener` is a utility interface that runs once the reload itself has completed, providing the fully-populated `ResourceManager` in its only method `#onResourceManagerReload()`. Classes implementing this interface mainly do post-reload cleanup work or build caches.
-
-### `PreparableReloadListener`
-
-Finally, `PreparableReloadListener` sits at the top of the hierarchy, and is the type accepted by the events above. It defines a method `#reload()` that returns a `CompletableFuture<Void>` and accepts four parameters:
-
-- `SharedState currentReload`: This holds the shared state of the reload, see below.
-- `Executor taskExecutor`: The `Executor` for the bulk of the tasks. This executor runs on multiple threads.
-- `PreparationBarrier barrier`: A threading barrier object. When creating a `CompletableFuture` yourself, a call to `thenCompose(barrier::wait)` should be added to make sure all the `CompletableFuture`s have caught up. See vanilla uses of `barrier#wait()` for reference.
-- `Executor reloadExecutor`: The `Executor` for tasks that need to run on the main tasks. Called the reload executor as commonly those are tasks towards the end of the reload.
-
-You can load basically anything here. For example, this is used by many reload listeners that load binary data ([textures][textures], fonts, etc., but not [sounds][sounds]), as well as some others such as [data maps][datamaps].
+`ResourceManagerReloadListener` is a special utility interface that runs once the reload itself has completed, providing the fully-populated `ResourceManager` in its only method `#onResourceManagerReload()`. Classes implementing this interface mainly do post-reload cleanup work or build caches.
 
 ## Shared Reloading State
 
-Reloading happens on multiple threads, as reload listeners are generally unrelated to one another. If you need to access another reload listener's values, you must set a shared state. To do so, in your reload listener, override the default `prepareSharedState()` method:
+As mentioned before, reloading happens on multiple threads since reload listeners are generally unrelated to one another. If you need to access another reload listener's values, you must set a shared state. To do so, in your reload listener, override the default `prepareSharedState()` method:
 
 ```java
 // Create a record (or class) holding our data to pass to another listener
@@ -213,16 +292,21 @@ public class MyReloadListener implements PreparableReloadListener {
 }
 ```
 
+The reload system will then ensure for you that the pending resources are available in the reload.
+
+[codec]: ../datastorage/codecs.md
 [conditions]: server/conditions.md
 [datamaps]: server/datamaps/index.md
 [datapackregistries]: ../concepts/registries.md#datapack-registries
 [events]: ../concepts/events.md
 [identifier]: ../misc/identifier.md
+[multithreading]: #multi-threaded-reloading
+[preparablereloadlistener]: #preparablereloadlistener
 [recipes]: server/recipes/index.md
 [resourcekey]: ../misc/identifier.md#resourcekeys
 [resources]: index.md
+[sharedstate]: #shared-reloading-state
 [sides]: ../concepts/sides.md
-[simplepreparablereloadlistener]: #simplepreparablereloadlistener
 [sounds]: client/sounds.md
 [soundsjson]: client/sounds.md#soundsjson
 [tags]: server/tags.md

--- a/docs/resources/reloadlisteners.md
+++ b/docs/resources/reloadlisteners.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 In some situations, integrating with the [existing resource systems][resources] provided by Minecraft or NeoForge just isn't going to cut it. Instead, having your system load files by itself from a resource or data pack is more desirable. For this purpose, you can register a custom reload listener, implementing `PreparableReloadListener` or one of its subinterfaces/subclasses.
 
-The idea behind a reload listener is simple: When a resource pack or data pack reload happens, the listener is called upon to read its contents from the new set of resource or data packs. It will then keep the contents until the next reload, at which point the contents will be discarded and the cycle starts anew.
+The idea behind a reload listener is simple: When a resource pack or data pack reload happens, the listener is called upon to read its contents from the new set of resource or data packs, loaded into a global `ResourceManager` and usually reference-copied into other places for easier access. It will then keep the contents until the next reload, at which point the contents will be discarded and the cycle starts anew.
 
 ## Reloading
 
@@ -16,7 +16,7 @@ Client reload listeners load from resource packs (the `assets` folder). The firs
 Server reload listeners load from data packs (the `data` folder). The first reload happens during world loading, which happens on world/server join on the physical client, and on startup on the physical server. Subsequent reloads are triggered using the `/reload` command, or by switching worlds/servers on the physical client.
 
 :::info
-The `/reload` command also triggers reloads of some other datapack-driven systems, such as datapack registries; this is by design and cannot be circumvented. Datapack registries are reloaded before reload listeners, meaning you can use their values in your server-side reload listeners if needed.
+The `/reload` command also triggers reloads of some other datapack-driven systems, such as [datapack registries][datapackregistries]; this is by design and cannot be circumvented. Datapack registries are reloaded before reload listeners, meaning you can use their values in your server-side reload listeners if needed.
 :::
 
 Reloading happens on multiple threads, as reload listeners are unrelated to one another. If you need to access another reload listener's values, consider delaying execution until the first use of your system after the reload has complete, or avoid access altogether.
@@ -112,7 +112,29 @@ And then simply access your values like so:
 MyObject myObject = MyReloadListener.INSTANCE.get(Identifier.fromNamespaceAndPath("mymod", "example"));
 ```
 
-Note that `SimpleJsonResourceReloadListener` goes through the resource packs top to bottom, and only retains the top-most entry for each filename. If you wish to perform merging (similar to e.g. [tags][tags]) or other operations that involve all the files for each filename from different resource/data packs, see the next section.
+Note that `SimpleJsonResourceReloadListener` goes through the resource packs top to bottom, and only retains the top-most entry for each filename. If you wish to perform merging (similar to e.g. [tags][tags]) or other operations that involve all the files for each filename from different resource/data packs, use a [`SimplePreparableReloadListener`][simplepreparablereloadlistener] instead.
+
+#### `FileToIdConverter`
+
+`FileToIdConverter` is a utility record used for converting filenames into [`Identifier`s][identifier]. It defines a namespace-local prefix and an extension, which are stripped away. For example:
+
+```java
+FileToIdConverter converter = new FileToIdConverter("mymod/my_listener", ".json");
+// Equivalent:
+FileToIdConverter converter = FileToIdConverter.json("mymod/my_listener");
+```
+
+The above converter will convert paths as follows:
+
+- `assets/mymod/mymod/my_listener/example_1.json` -> `mymod:example_1`
+- `assets/mymod/mymod/my_listener/subfolder/example_2.json` -> `mymod:subfolder/example_2`
+- `assets/othermod/mymod/my_listener/example_3.json` -> `othermod:example_3`
+
+Besides `FileToIdConverter#json()`, there is an additional helper `FileToIdConverter#registry()` that accepts a [`ResourceKey<? extends Registry<?>>`][resourcekey] and converts the registry key to a namespace-and-path string, like the ones above.
+
+:::tip
+In order to avoid conflicts where two mods add a registry that is named the same, it is strongly recommended to prefix your reload listener's folder with a folder named after the mod id, as seen above with `mymod/my_listener`.
+:::
 
 ### `SimplePreparableReloadListener`
 
@@ -124,20 +146,34 @@ For a simple reference implementation of `SimplePreparableReloadListener` that l
 
 ### `ContextAwareReloadListener`
 
-TODO
+Next up in the hierarchy is `ContextAwareReloadListener`. This is a utility class added into the hierarchy by NeoForge in order to supply a [load condition][conditions] context, obtainable via `#getContext()`. Additionally, it provides a registry access via `#getRegistryLookup`.
+
+### `ResourceManagerReloadListener`
+
+Outside the class hierarchy described so far, `ResourceManagerReloadListener` is a utility interface that runs once the reload itself has completed, providing the fully-populated `ResourceManager` in its only method `#onResourceManagerReload`. Classes implementing this interface mainly do post-reload cleanup work or build caches.
 
 ### `PreparableReloadListener`
 
-TODO
+Finally, `PreparableReloadListener` sits at the top of the hierarchy, and is the type accepted by the events above. It defines a method `#reload` that returns a `CompletableFuture<Void>` and accepts four parameters:
 
-## `FileToIdConverter`
+- `PreparableReloadListener.SharedState currentReload`: This holds the "global state" of the reload, most notably including the partially-initialized `ResourceManager`.
+- `Executor taskExecutor`: The `Executor` for the bulk of the tasks. This executor runs on multiple threads.
+- `PreparableReloadListener.PreparationBarrier barrier`: A threading barrier object. When creating a `CompletableFuture` yourself, a call to `thenCompose(barrier::wait)` should be added to make sure all the `CompletableFuture`s have caught up. See vanilla uses of `barrier#wait()` for reference.
+- `Executor reloadExecutor`: The `Executor` for tasks that need to run on the main tasks. Called the reload executor as commonly those are tasks towards the end of the reload.
 
-TODO
+You can load basically anything here. For example, this is used by many reload listeners that load binary data ([textures][textures], fonts, etc., but not [sounds][sounds]), as well as some others such as [data maps][datamaps].
 
+[conditions]: server/conditions.md
+[datamaps]: server/datamaps/index.md
+[datapackregistries]: ../concepts/registries.md#datapack-registries
 [events]: ../concepts/events.md
+[identifier]: ../misc/identifier.md
 [recipes]: server/recipes/index.md
+[resourcekey]: ../misc/identifier.md#resourcekeys
 [resources]: index.md
 [sides]: ../concepts/sides.md
+[simplepreparablereloadlistener]: #simplepreparablereloadlistener
+[sounds]: client/sounds.md
 [soundsjson]: client/sounds.md#soundsjson
 [tags]: server/tags.md
 [textures]: client/textures.md

--- a/docs/resources/reloadlisteners.md
+++ b/docs/resources/reloadlisteners.md
@@ -1,0 +1,132 @@
+# Reload Listeners
+
+In some situations, integrating with the existing resource systems provided by Minecraft or NeoForge just isn't going to cut it. Instead, having your system load files by itself from a resource or data pack is more desirable. For this purpose, you can register a custom reload listener, implementing `PreparableReloadListener` or one of its subinterfaces/subclasses.
+
+The idea behind a reload listener is simple: When a resource pack or data pack reload happens, the listener is called upon to read its contents from the new set of resource or data packs. It will then keep the contents until the next reload, at which point the contents will be discarded and the cycle starts anew.
+
+## Reloading
+
+Both resource pack and data pack reload function similar in principle, and only differ in timing and the location files are loaded from.
+
+Client reload listeners load from resource packs (the `assets` folder). The first reload happens during startup on the physical client, and **never** on the physical server. Subsequent reloads are triggered when resource packs are changed in the Options menu, or by pressing F3+T.
+
+Server reload listeners load from data packs (the `data` folder). The first reload happens during world loading, which happens on world/server join on the physical client, and on startup on the physical server. Subsequent reloads are triggered using the `/reload` command, or by switching worlds/servers on the physical client.
+
+:::info
+The `/reload` command also triggers reloads of some other datapack-driven systems, such as datapack registries; this is by design and cannot be circumvented. Datapack registries are reloaded before reload listeners, meaning you can use their values in your server-side reload listeners if needed.
+:::
+
+Reloading happens on multiple threads, as reload listeners are unrelated to one another. If you need to access another reload listener's values, consider delaying execution until the first use of your system after the reload has complete, or avoid access altogether.
+
+## Adding a Reload Listener
+
+All reload listeners are registered using the same basic principle. First, we need a reload listener instance. Vanilla typically stores its reload listeners, such as the texture or recipe managers, as fields in `Minecraft` (for client-side listeners) or `ServerLevel` (for server-side listeners), however in modded contexts, a singleton instance is usually fine as well:
+
+```java
+// Instead of PreparableReloadListener, extend one of its subclasses if applicable, see below.
+public class MyReloadListener implements PreparableReloadListener {
+    // The id we're going to use in registration below
+    public static final Identifier ID = Identifier.fromNamespaceAndPath("mymod", "my_listener");
+    // The instance through which the listener is accessed
+    public static final MyReloadListener INSTANCE = new MyReloadListener();
+    
+    // Hide the constructor in accordance with the singleton pattern
+    private MyReloadListener() {}
+
+    // other methods added here later
+}
+```
+
+Then, depending on whether the reload listener is for client data (resource packs) or server data (data packs), the listener is registered to one of two events:
+
+```java
+// For client-side reload listeners
+@SubscribeEvent // on the game event bus only on the physical client
+public static void addClientReloadListeners(AddClientReloadListenersEvent event) {
+    event.addListener(MyReloadListener.ID, MyReloadListener.INSTANCE);
+}
+
+// For server-side reload listeners
+@SubscribeEvent // on the game event bus
+public static void addServerReloadListeners(AddServerReloadListenersEvent event) {
+    event.addListener(MyReloadListener.ID, MyReloadListener.INSTANCE);
+}
+```
+
+:::danger
+Do not register the same reload listener on both sides! All of your file-driven systems should be designed for one side only, otherwise behavior might differ between singleplayer and multiplayer.
+:::
+
+And then, the reload listener can be accessed - from the correct side - through the singleton `INSTANCE`.
+
+## Types of Reload Listeners
+
+All reload listeners implement the `PreparableReloadListener` interface. However, in order to make things more understandable, we will first cover the `SimpleJsonResourceReloadListener`, which is used to load JSON files and implements most things for you already. Then, we will gradually go up the class hierarchy and explain what is done for you and what you can modify yourself in each level.
+
+### `SimpleJsonResourceReloadListener`
+
+`SimpleJsonResourceReloadListener<T>` is what you want to use for loading most JSON files. It scans a certain folder for JSON files, converts the contents into objects according to the provided codec, puts the filenames and associated objects into a `Map<Identifier, T>`, and provides that map to you in `#apply`. The simplest implementation looks like this:
+
+```java
+// Assuming a type MyObject, and MyObject.CODEC to be a Codec<MyObject>.
+public class MyReloadListener extends SimpleJsonResourceReloadListener<MyObject> {
+    // As above.
+    public static final Identifier ID = Identifier.fromNamespaceAndPath("mymod", "my_listener");
+    public static final MyReloadListener INSTANCE = new MyReloadListener();
+    // This map will store our values.
+    private final Map<Identifier, MyObject> values = new HashMap<>();
+
+    private MyReloadListener() {
+        // Add a super call here. The parameters are the codec
+        // and a FileToIdConverter, see the FileToIdConverter section below.
+        super(MyObject.CODEC, FileToIdConverter.json("mymod/my_listener"));
+    }
+
+    @Override
+    protected void apply(Map<Identifier, MyObject> map, ResourceManager resourceManager, ProfilerFiller profiler) {
+        // Clear out the old values.
+        values.clear();
+        // In the most simple implementation, blindly add all the values we get into the map.
+        // If needed, you can perform validations, duplicate removal or similar here.
+        values.putAll(map);
+    }
+
+    // Provide access to the values in whatever way you deem necessary. For example:
+    @Nullable
+    public MyObject get(Identifier id) {
+        return values.get(id);
+    }
+
+    public Map<Identifier, MyObject> getAll() {
+        return Collections.unmodifiableMap(values);
+    }
+}
+```
+
+And then simply access your values like so:
+
+```java
+MyObject myObject = MyReloadListener.INSTANCE.get(Identifier.fromNamespaceAndPath("mymod", "example"));
+```
+
+Note that `SimpleJsonResourceReloadListener` goes through the resource packs top to bottom, and only retains the top-most entry for each filename. If you wish to perform merging (similar to e.g. tags) or other operations that involve all the files for each filename from different resource/data packs, see the next section.
+
+### `SimplePreparableReloadListener`
+
+`SimplePreparableReloadListener<T>` sits a layer above `SimpleJsonResourceReloadListener<T>`, and is also usable for non-JSON files, as well as (JSON or non-JSON) files with the same name from different resource/data packs.
+
+`SimplePreparableReloadListener<T>` splits its reload into two distinct cycles: `prepare` and `apply`. First, `prepare` is called to collect the files and convert them into `T`s. Once **all** files have been collected, `apply` is called to do something with them - usually store them for later use.
+
+For a simple reference implementation of `SimplePreparableReloadListener` that loads from a single file, see `SplashManager`. For an implementation for merging JSON files, see `SoundManager#prepare`, `SoundManager#apply` and the related fields in `SoundManager`.
+
+### `ContextAwareReloadListener`
+
+TODO
+
+### `PreparableReloadListener`
+
+TODO
+
+## `FileToIdConverter`
+
+TODO

--- a/docs/resources/reloadlisteners.md
+++ b/docs/resources/reloadlisteners.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 3
+---
 # Reload Listeners
 
 In some situations, integrating with the existing resource systems provided by Minecraft or NeoForge just isn't going to cut it. Instead, having your system load files by itself from a resource or data pack is more desirable. For this purpose, you can register a custom reload listener, implementing `PreparableReloadListener` or one of its subinterfaces/subclasses.

--- a/docs/resources/reloadlisteners.md
+++ b/docs/resources/reloadlisteners.md
@@ -64,11 +64,22 @@ And then, the reload listener can be accessed - from the correct side - through 
 
 ## Types of Reload Listeners
 
+```mermaid
+graph LR;
+    PreparableReloadListener --> ResourceManagerReloadListener;
+    PreparableReloadListener --> ContextAwareReloadListener --> SimplePreparableReloadListener --> SimpleJsonResourceReloadListener;
+    
+    class PreparableReloadListener,ResourceManagerReloadListener green;
+    class ContextAwareReloadListener,SimplePreparableReloadListener,SimpleJsonResourceReloadListener blue;
+```
+
+_Interfaces in green, abstract classes in blue._
+
 All reload listeners implement the `PreparableReloadListener` interface. However, in order to make things more understandable, we will first cover the `SimpleJsonResourceReloadListener`, which is used to load JSON files and implements most things for you already. Then, we will gradually go up the class hierarchy and explain what is done for you and what you can modify yourself in each level.
 
 ### `SimpleJsonResourceReloadListener`
 
-`SimpleJsonResourceReloadListener<T>` is what you want to use for loading most JSON files. It scans a certain folder for JSON files, converts the contents into objects according to the provided codec, puts the filenames and associated objects into a `Map<Identifier, T>`, and provides that map to you in `#apply`. The simplest implementation looks like this:
+`SimpleJsonResourceReloadListener<T>` is what you want to use for loading most JSON files. It scans a certain folder for JSON files, converts the contents into objects according to the provided codec, puts the filenames and associated objects into a `Map<Identifier, T>`, and provides that map to you in `#apply()`. The simplest implementation looks like this:
 
 ```java
 // Assuming a type MyObject, and MyObject.CODEC to be a Codec<MyObject>.
@@ -142,19 +153,19 @@ In order to avoid conflicts where two mods add a registry that is named the same
 
 `SimplePreparableReloadListener<T>` splits its reload into two distinct cycles: `prepare` and `apply`. First, `prepare` is called to collect the files and convert them into `T`s. Once **all** files have been collected, `apply` is called to do something with them - usually store them for later use.
 
-For a simple reference implementation of `SimplePreparableReloadListener` that loads from a single file, see `SplashManager`. For an implementation for merging JSON files, see the merging of [`sounds.json`][soundsjson] in `SoundManager#prepare`, `SoundManager#apply` and the related fields in `SoundManager`.
+For a simple reference implementation of `SimplePreparableReloadListener` that loads from a single file, see `SplashManager`. For an implementation for merging JSON files, see the merging of [`sounds.json`][soundsjson] in `SoundManager#prepare()`, `SoundManager#apply()` and the related fields in `SoundManager`. For an implementation of folder scanning, see `SimpleJsonResourceReloadListener#prepare()`.
 
 ### `ContextAwareReloadListener`
 
-Next up in the hierarchy is `ContextAwareReloadListener`. This is a utility class added into the hierarchy by NeoForge in order to supply a [load condition][conditions] context, obtainable via `#getContext()`. Additionally, it provides a registry access via `#getRegistryLookup`.
+Next up in the hierarchy is `ContextAwareReloadListener`. This is a utility class added into the hierarchy by NeoForge in order to supply a [load condition][conditions] context, obtainable via `#getContext()`. Additionally, it provides a registry access via `#getRegistryLookup()`.
 
 ### `ResourceManagerReloadListener`
 
-Outside the class hierarchy described so far, `ResourceManagerReloadListener` is a utility interface that runs once the reload itself has completed, providing the fully-populated `ResourceManager` in its only method `#onResourceManagerReload`. Classes implementing this interface mainly do post-reload cleanup work or build caches.
+Outside the class hierarchy described so far, `ResourceManagerReloadListener` is a utility interface that runs once the reload itself has completed, providing the fully-populated `ResourceManager` in its only method `#onResourceManagerReload()`. Classes implementing this interface mainly do post-reload cleanup work or build caches.
 
 ### `PreparableReloadListener`
 
-Finally, `PreparableReloadListener` sits at the top of the hierarchy, and is the type accepted by the events above. It defines a method `#reload` that returns a `CompletableFuture<Void>` and accepts four parameters:
+Finally, `PreparableReloadListener` sits at the top of the hierarchy, and is the type accepted by the events above. It defines a method `#reload()` that returns a `CompletableFuture<Void>` and accepts four parameters:
 
 - `PreparableReloadListener.SharedState currentReload`: This holds the "global state" of the reload, most notably including the partially-initialized `ResourceManager`.
 - `Executor taskExecutor`: The `Executor` for the bulk of the tasks. This executor runs on multiple threads.

--- a/docs/resources/server/_category_.json
+++ b/docs/resources/server/_category_.json
@@ -1,3 +1,4 @@
 {
-    "label": "Server"
+    "label": "Server",
+    "position": 2
 }

--- a/docs/resources/server/datamaps/index.md
+++ b/docs/resources/server/datamaps/index.md
@@ -2,7 +2,7 @@
 
 A data map contains data-driven, reloadable objects that can be attached to a registered object. This system allows for more easily data-driving game behavior, as they provide functionality such as syncing or conflict resolution, leading to a better and more configurable user experience. You can think of [tags] as registry object ➜ boolean maps, while data maps are more flexible registry object ➜ object maps. Similar to [tags], data maps will add to their corresponding data map rather than overwriting.
 
-Data maps can be attached to both static, built-in, registries and dynamic data-driven datapack registries. Data maps support reloading through the use of the `/reload` command or any other means that reload server resources.
+Data maps can be attached to both static, built-in, registries and dynamic data-driven datapack registries. Data maps support [reloading][reloading] through the use of the `/reload` command or any other means that reload server resources.
 
 NeoForge provides various [built-in data maps][builtin] for common use cases, replacing hardcoded vanilla fields. More info can be found in the linked article.
 
@@ -380,5 +380,6 @@ public static void gatherData(GatherDataEvent.Client event) {
 [add]: #adding-values
 [mergers]: #mergers
 [modbus]: ../../../concepts/events.md#event-buses
+[reloading]: ../../reloadlisteners.md#reloading
 [removers]: #removers
 [tags]: ../tags.md

--- a/docs/resources/server/recipes/custom.md
+++ b/docs/resources/server/recipes/custom.md
@@ -548,7 +548,7 @@ public class RightClickBlockRecipe implements Recipe<RightClickBlockInput> {
 
 Now that all parts of your recipe are complete, you can make yourself some recipe JSONs (see the [datagen] section for that) and then query the recipe manager for your recipes, like above. What you then do with the recipe is up to you. A common use case would be a machine that can process your recipes, storing the active recipe as a field.
 
-In our case, however, we want to apply the recipe when an item is right-clicked on a block. We will do so using an [event handler][event]. Keep in mind that this is an example implementation, and you can alter this in any way you like (so long as you run it on the server). As we want the interaction state to match on both the client and server, we will also need to [sync any relevant input states across the network][networking].
+In our case, however, we want to apply the recipe when an item is right-clicked on a block. We will do so using a [reload listener][reloadlistener] and an [event handler][event]. Keep in mind that this is an example implementation, and you can alter this in any way you like (so long as you run it on the server). As we want the interaction state to match on both the client and server, we will also need to [sync any relevant input states across the network][networking].
 
 We can set up a simple network implementation to sync the recipe inputs like so:
 
@@ -1015,6 +1015,7 @@ It is also possible to have `SimpleRecipeBuilder` be merged into `RightClickBloc
 [ingredients]: ingredients.md
 [networking]: ../../../networking/payload.md
 [recipedatagen]: index.md#data-generation
+[reloadlistener]: ../../reloadlisteners.md
 [registry]: ../../../concepts/registries.md#methods-for-registering
 [serializer]: #the-recipe-serializer
 [streamcodec]: ../../../networking/streamcodecs.md


### PR DESCRIPTION
Adds reload listener docs. Since this covers both client and server (as they are almost the same), they are placed in the root Resources folder.

~~Opening as draft as it is not yet complete. At the time of writing, the second half of the article, as well as any and all links, are missing.~~ **EDIT:** Done.

Closes #306 .

------------------
Preview URL: https://pr-368.neoforged-docs-previews.pages.dev