### PR TITLE
Fix `Data Generation#MyRecipeProvider` example in versioned_docs/version-1.21.1/resources/server/recipes/index.md

### DIFF
--- a/versioned_docs/version-1.21.1/resources/server/recipes/index.md
+++ b/versioned_docs/version-1.21.1/resources/server/recipes/index.md
@@ -384,7 +384,7 @@ Like most other JSON files, recipes can be datagenned. For recipes, we want to e
 public class MyRecipeProvider extends RecipeProvider {
     // Get the parameters from GatherDataEvent.
     public MyRecipeProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider) {
-        super(output, registries);
+        super(output, lookupProvider);
     }
 
     @Override


### PR DESCRIPTION
Correct `super(output, registries)` to `super(output, lookupProvider)` to match the parameter.

------------------
Preview URL: https://pr-370.neoforged-docs-previews.pages.dev